### PR TITLE
fix: resolve infinite recursion in user_bands RLS policy

### DIFF
--- a/supabase/migrations/012_fix_user_bands_recursion.sql
+++ b/supabase/migrations/012_fix_user_bands_recursion.sql
@@ -1,0 +1,12 @@
+-- Fix infinite recursion in user_bands RLS policy
+-- The old policy was querying user_bands within its own USING clause, causing infinite recursion
+
+-- Drop the problematic policy
+DROP POLICY IF EXISTS "Users can view their band memberships" ON user_bands;
+
+-- Recreate with simple, non-recursive logic
+-- Users can only view their own band memberships (their own rows in user_bands)
+CREATE POLICY "Users can view their band memberships"
+  ON user_bands FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());


### PR DESCRIPTION
This commit introduces a new SQL migration that fixes an infinite recursion issue in the user_bands row-level security (RLS) policy. The previous policy queried user_bands within its own USING clause, leading to recursion. The problematic policy has been dropped and replaced with a simplified version that allows authenticated users to view only their own band memberships, ensuring proper data isolation and security.