### PR TITLE
chore: Streamline Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,47 +1,40 @@
 version: 2
 updates:
   # Enable version updates for npm
+  # Note: Runs Tuesday to avoid race condition with custom workflow (Monday 9 AM)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "tuesday"
       time: "09:00"
-    open-pull-requests-limit: 10
-    reviewers:
-      - "jason" # Replace with actual username if different
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "automated"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
-    # Group minor and patch updates together
-    groups:
-      development-dependencies:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-      production-dependencies:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-    # Auto-merge rules for trusted packages (requires branch protection)
-    # Uncomment when ready to enable auto-merge
-    # allow:
-    #   - dependency-type: "development"
-    # ignore:
-    #   - dependency-name: "react"
-    #     update-types: ["version-update:semver-major"]
+    # Ignore packages handled elsewhere or deferred
+    ignore:
+      # ESLint ecosystem - defer to coordinated migration (see PRs #21, #22)
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@typescript-eslint/*"
+        update-types: ["version-update:semver-major"]
+      # Husky - stay on v8, v9 requires hook reconfiguration (see PR #23)
+      - dependency-name: "husky"
+        update-types: ["version-update:semver-major"]
+    # Note: Groups removed - custom workflow (dependency-update.yml) handles
+    # minor/patch updates with build verification before creating PRs
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "tuesday"
+      time: "10:00"
     labels:
       - "github-actions"
       - "automated"


### PR DESCRIPTION
## Summary

Streamlines Dependabot configuration to work better with existing custom dependency update workflow.

### Changes
- **Moved schedule to Tuesday** to avoid race condition with custom workflow (Monday 9 AM)
- **Removed** dev/prod dependency groups (custom workflow in `dependency-update.yml` handles minor/patch updates with build verification)
- **Added ignores** for deferred major updates:
  - ESLint ecosystem (`eslint`, `@typescript-eslint/*`) - requires coordinated migration to ESLint 9
  - Husky - current v8 setup works well, v9 requires hook reconfiguration
- **Reduced** `open-pull-requests-limit` from 10 to 5
- **Added explicit schedule** for GitHub Actions (Tuesday 10 AM)
- **Added PR references** to ignore comments for tracking

### Related PRs Processed
- Merged: #20 (@types/node), #19 (eslint-plugin-react-hooks), #17 (vite 7), #11-15 (GitHub Actions)
- Closed: #22 (ESLint 9), #21 (typescript-eslint), #23 (husky 9), #18 (typescript-eslint/parser), #28 (conflicts)

### Dependency Management Strategy
- **Custom workflow** (`dependency-update.yml`) → Monday 9 AM, weekly minor/patch updates with build verification
- **Dependabot** → Tuesday 9-10 AM, GitHub Actions updates + major version alerts for production deps

### Reviewer Feedback Addressed
- ✅ Offset schedule to avoid race condition (Monday → Tuesday)
- ✅ Added PR references for tracking deferred migrations
- ✅ Added explicit time for GitHub Actions schedule
- ℹ️ Reviewer assignment not restored (intentionally simplified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)