### PR TITLE
chore(deps): add react-router-dom to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,9 @@ updates:
       # Husky - stay on v8, v9 requires hook reconfiguration (see PR #23)
       - dependency-name: "husky"
         update-types: ["version-update:semver-major"]
+      # React Router - stay on v6, v7 requires migration (see PR #41)
+      - dependency-name: "react-router-dom"
+        update-types: ["version-update:semver-major"]
     # Note: Groups removed - custom workflow (dependency-update.yml) handles
     # minor/patch updates with build verification before creating PRs
 


### PR DESCRIPTION
## Summary
Adds react-router-dom to the Dependabot ignore list for major version updates.

## Context
After merging PR #36 (Dependabot config streamlining), GitHub automatically re-ran Dependabot which created 6 new PRs. These were resolved as follows:

- **Merged:** #37 (actions/cache v4), #38 (peter-evans/create-pull-request v7)
- **Closed:** #39, #40, #42 (patches/minor - handled by custom workflow)
- **Closed with ignore:** #41 (react-router-dom v7 - breaking changes)

This PR adds react-router-dom to the ignore list alongside ESLint, typescript-eslint, and Husky to prevent future major version PRs until we're ready to migrate.

## Changes
- Added `react-router-dom` to dependabot.yml ignore list for semver-major updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)