### PR TITLE
fix(practice): ensure transport controls visible on mobile with fade indicators

### DIFF
--- a/src/components/practice/PlaybackControls.tsx
+++ b/src/components/practice/PlaybackControls.tsx
@@ -29,9 +29,9 @@ export const PlaybackControls = memo(function PlaybackControls({
   onToggleLoop,
 }: PlaybackControlsProps) {
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-0.5 sm:gap-1">
       <TooltipProvider delayDuration={100}>
-        {/* Play/Pause Button */}
+        {/* Play/Pause Button - primary action, larger and prominent */}
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
@@ -40,12 +40,14 @@ export const PlaybackControls = memo(function PlaybackControls({
               onClick={isPlaying ? onPause : onPlay}
               disabled={disabled}
               className={cn(
-                'h-10 w-10 rounded-full p-0',
-                isPlaying && 'bg-primary text-primary-foreground hover:bg-primary/90'
+                'h-11 w-11 sm:h-10 sm:w-10 rounded-full p-0 shrink-0',
+                isPlaying
+                  ? 'bg-primary text-primary-foreground hover:bg-primary/90 shadow-md'
+                  : 'hover:bg-muted'
               )}
               aria-label={isPlaying ? 'Pause' : 'Play'}
             >
-              {isPlaying ? <Pause size={18} /> : <Play size={18} className="ml-0.5" />}
+              {isPlaying ? <Pause size={20} /> : <Play size={20} className="ml-0.5" />}
             </Button>
           </TooltipTrigger>
           <TooltipContent>
@@ -61,7 +63,7 @@ export const PlaybackControls = memo(function PlaybackControls({
               size="sm"
               onClick={onStop}
               disabled={disabled}
-              className="h-11 w-11 sm:h-9 sm:w-9 p-0"
+              className="h-10 w-10 sm:h-9 sm:w-9 p-0 shrink-0"
               aria-label="Stop"
             >
               <Square size={16} />
@@ -81,7 +83,7 @@ export const PlaybackControls = memo(function PlaybackControls({
               onClick={onToggleLoop}
               disabled={disabled}
               className={cn(
-                'h-11 w-11 sm:h-9 sm:w-9 p-0',
+                'h-10 w-10 sm:h-9 sm:w-9 p-0 shrink-0',
                 isLooping && 'bg-primary text-primary-foreground hover:bg-primary/90'
               )}
               aria-label={isLooping ? 'Disable loop' : 'Enable loop'}

--- a/src/components/practice/PracticeControlBar.tsx
+++ b/src/components/practice/PracticeControlBar.tsx
@@ -1,5 +1,5 @@
-import { memo } from 'react';
-import { PanelLeftClose, PanelLeftOpen, Clock } from 'lucide-react';
+import { memo, useRef, useState, useCallback, useLayoutEffect } from 'react';
+import { PanelLeftClose, PanelLeftOpen, Clock, ChevronLeft, ChevronRight } from 'lucide-react';
 import {
   Button,
   Tooltip,
@@ -8,6 +8,7 @@ import {
   TooltipTrigger,
 } from '@/components/primitives';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/hooks/useBreakpoint';
 import { PlaybackControls } from './PlaybackControls';
 import { ChartTabs } from './ChartTabs';
 import { TrackSelector } from './TrackSelector';
@@ -16,6 +17,126 @@ import { MetronomeIndicator } from './MetronomeIndicator';
 import { ProgressBar } from './ProgressBar';
 import type { Song, SongChart } from '@/types';
 import type { TrackInfo, PlaybackState, MetronomeState } from './types';
+
+// =============================================================================
+// SCROLLABLE CONTAINER WITH FADE INDICATORS
+// =============================================================================
+
+interface ScrollableContainerProps {
+  children: React.ReactNode;
+  className?: string;
+  fadeClassName?: string;
+}
+
+/**
+ * A horizontally scrollable container with fade gradient overlays
+ * that indicate when more content is available to scroll.
+ */
+const ScrollableContainer = memo(function ScrollableContainer({
+  children,
+  className,
+  fadeClassName = 'from-card',
+}: ScrollableContainerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [showLeftFade, setShowLeftFade] = useState(false);
+  const [showRightFade, setShowRightFade] = useState(false);
+  // Track if initial check has been done to avoid re-running on each render
+  const hasInitialized = useRef(false);
+
+  const checkScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const { scrollLeft, scrollWidth, clientWidth } = el;
+    const hasOverflow = scrollWidth > clientWidth;
+
+    setShowLeftFade(hasOverflow && scrollLeft > 4);
+    setShowRightFade(hasOverflow && scrollLeft < scrollWidth - clientWidth - 4);
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    // Set up scroll listener
+    const handleScroll = () => checkScroll();
+    el.addEventListener('scroll', handleScroll, { passive: true });
+
+    // Set up resize observer to detect content/container size changes
+    const resizeObserver = new ResizeObserver(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Intentional: resize observer callback is async external system update
+      checkScroll();
+    });
+    resizeObserver.observe(el);
+
+    // Initial check after layout settles (deferred to avoid sync setState in effect body)
+    if (!hasInitialized.current) {
+      hasInitialized.current = true;
+      requestAnimationFrame(() => {
+        checkScroll();
+      });
+    }
+
+    return () => {
+      el.removeEventListener('scroll', handleScroll);
+      resizeObserver.disconnect();
+    };
+  }, [checkScroll]);
+
+  return (
+    <div className="relative min-w-0 flex-1">
+      {/* Left fade indicator */}
+      <div
+        className={cn(
+          'pointer-events-none absolute left-0 top-0 bottom-0 w-6 z-10',
+          'bg-gradient-to-r to-transparent transition-opacity duration-200',
+          fadeClassName,
+          showLeftFade ? 'opacity-100' : 'opacity-0'
+        )}
+        aria-hidden="true"
+      >
+        <ChevronLeft
+          size={14}
+          className={cn(
+            'absolute left-0.5 top-1/2 -translate-y-1/2 text-muted-foreground',
+            'transition-opacity duration-200',
+            showLeftFade ? 'opacity-60' : 'opacity-0'
+          )}
+        />
+      </div>
+
+      {/* Scrollable content */}
+      <div
+        ref={scrollRef}
+        className={cn('overflow-x-auto scrollbar-hide', className)}
+      >
+        {children}
+      </div>
+
+      {/* Right fade indicator */}
+      <div
+        className={cn(
+          'pointer-events-none absolute right-0 top-0 bottom-0 w-6 z-10',
+          'bg-gradient-to-l to-transparent transition-opacity duration-200',
+          fadeClassName,
+          showRightFade ? 'opacity-100' : 'opacity-0'
+        )}
+        aria-hidden="true"
+      >
+        <ChevronRight
+          size={14}
+          className={cn(
+            'absolute right-0.5 top-1/2 -translate-y-1/2 text-muted-foreground',
+            'transition-opacity duration-200',
+            showRightFade ? 'opacity-60' : 'opacity-0'
+          )}
+        />
+      </div>
+    </div>
+  );
+});
+
+ScrollableContainer.displayName = 'ScrollableContainer';
 
 export interface PracticeControlBarProps {
   // Song info
@@ -84,12 +205,28 @@ export const PracticeControlBar = memo(function PracticeControlBar({
   onMetronomeBpmChange,
   onMetronomeToggle,
 }: PracticeControlBarProps) {
+  const isMobile = useIsMobile();
+
+  // Determine if we should show the GP controls row
+  const showGpControlsRow =
+    isGuitarPro && playbackState && onPlay && onPause && onStop && onToggleLoop;
+
+  // Determine if we have secondary controls to show (track, tempo, metronome for GP)
+  const hasSecondaryGpControls =
+    isGuitarPro &&
+    playbackState &&
+    tracks &&
+    currentTrackIndex !== undefined &&
+    onSelectTrack &&
+    onToggleTrackMute &&
+    onToggleTrackSolo;
+
   return (
     <header className="border-b border-border bg-card shrink-0" data-testid="practice-control-bar">
-      {/* Main control row */}
-      <div className="flex items-center gap-4 px-4 py-2 h-14">
+      {/* Main control row - Song info + Chart tabs */}
+      <div className="flex items-center gap-2 sm:gap-4 px-3 sm:px-4 py-2 h-14">
         {/* Left: Toggle + Song info */}
-        <div className="flex items-center gap-3 min-w-0 shrink-0">
+        <div className="flex items-center gap-2 sm:gap-3 min-w-0 shrink-0">
           <TooltipProvider delayDuration={100}>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -97,7 +234,7 @@ export const PracticeControlBar = memo(function PracticeControlBar({
                   variant="ghost"
                   size="sm"
                   onClick={onToggleSongList}
-                  className={cn('h-9 w-9 p-0', showSongList && 'bg-muted')}
+                  className={cn('h-11 w-11 sm:h-9 sm:w-9 p-0', showSongList && 'bg-muted')}
                   aria-label={showSongList ? 'Hide song list' : 'Show song list'}
                   data-testid="toggle-button"
                 >
@@ -110,8 +247,8 @@ export const PracticeControlBar = memo(function PracticeControlBar({
             </Tooltip>
           </TooltipProvider>
 
-          <div className="min-w-0">
-            <h2 className="text-lg font-bold font-serif text-foreground truncate">
+          <div className="min-w-0 max-w-[120px] sm:max-w-none">
+            <h2 className="text-base sm:text-lg font-bold font-serif text-foreground truncate">
               {song?.title || 'Select a Song'}
             </h2>
             {song && (
@@ -119,8 +256,8 @@ export const PracticeControlBar = memo(function PracticeControlBar({
                 <span className="font-mono tabular-nums">{song.bpm} BPM</span>
                 {song.key && (
                   <>
-                    <span className="text-border">•</span>
-                    <span>Key of {song.key}</span>
+                    <span className="text-border hidden sm:inline">•</span>
+                    <span className="hidden sm:inline">Key of {song.key}</span>
                   </>
                 )}
               </div>
@@ -128,9 +265,10 @@ export const PracticeControlBar = memo(function PracticeControlBar({
           </div>
         </div>
 
-        {/* Center: Playback + Charts - flex-1, centered, with responsive overflow handling */}
-        <div className="flex-1 flex items-center justify-center gap-2 sm:gap-4 min-w-0 overflow-x-auto scrollbar-hide">
-          {isGuitarPro && playbackState && onPlay && onPause && onStop && onToggleLoop && (
+        {/* Center/Right: Chart tabs (desktop also includes playback) */}
+        <ScrollableContainer className="flex items-center justify-center sm:justify-end gap-2 sm:gap-4">
+          {/* Desktop only: inline playback controls */}
+          {!isMobile && showGpControlsRow && (
             <PlaybackControls
               isPlaying={playbackState.isPlaying}
               isLooping={playbackState.isLooping}
@@ -148,21 +286,17 @@ export const PracticeControlBar = memo(function PracticeControlBar({
             onSelectChart={onSelectChart}
             panelId={chartPanelId}
           />
-        </div>
 
-        {/* Right: Track/BPM/Metronome - with responsive overflow handling */}
-        <div className="flex items-center gap-2 sm:gap-3 shrink-0 overflow-x-auto scrollbar-hide max-w-[50%] sm:max-w-none">
-          {isGuitarPro && playbackState && tracks && currentTrackIndex !== undefined ? (
+          {/* Desktop only: secondary GP controls */}
+          {!isMobile && hasSecondaryGpControls && (
             <>
-              {onSelectTrack && onToggleTrackMute && onToggleTrackSolo && (
-                <TrackSelector
-                  tracks={tracks}
-                  currentTrackIndex={currentTrackIndex}
-                  onSelectTrack={onSelectTrack}
-                  onToggleMute={onToggleTrackMute}
-                  onToggleSolo={onToggleTrackSolo}
-                />
-              )}
+              <TrackSelector
+                tracks={tracks}
+                currentTrackIndex={currentTrackIndex}
+                onSelectTrack={onSelectTrack}
+                onToggleMute={onToggleTrackMute}
+                onToggleSolo={onToggleTrackSolo}
+              />
 
               {onSetBPM && onResetTempo && (
                 <TempoControl
@@ -176,8 +310,11 @@ export const PracticeControlBar = memo(function PracticeControlBar({
 
               <MetronomeIndicator currentBeat={playbackState.metronomeBeat} />
             </>
-          ) : (
-            // Non-GP metronome controls
+          )}
+
+          {/* Desktop only: non-GP metronome */}
+          {!isMobile &&
+            !isGuitarPro &&
             metronomeState &&
             onMetronomeBpmChange &&
             onMetronomeToggle && (
@@ -217,10 +354,100 @@ export const PracticeControlBar = memo(function PracticeControlBar({
                   {metronomeState.bpm}
                 </span>
               </div>
-            )
-          )}
-        </div>
+            )}
+        </ScrollableContainer>
       </div>
+
+      {/* Mobile: Dedicated transport controls row for GP */}
+      {isMobile && showGpControlsRow && (
+        <div className="flex items-center gap-2 px-3 py-2 border-t border-border/50 bg-card/80">
+          {/* Transport controls - always visible on mobile */}
+          <div className="shrink-0">
+            <PlaybackControls
+              isPlaying={playbackState.isPlaying}
+              isLooping={playbackState.isLooping}
+              disabled={!song}
+              onPlay={onPlay}
+              onPause={onPause}
+              onStop={onStop}
+              onToggleLoop={onToggleLoop}
+            />
+          </div>
+
+          {/* Secondary controls - scrollable with fade */}
+          <ScrollableContainer className="flex items-center gap-2">
+            {hasSecondaryGpControls && (
+              <>
+                <TrackSelector
+                  tracks={tracks}
+                  currentTrackIndex={currentTrackIndex}
+                  onSelectTrack={onSelectTrack}
+                  onToggleMute={onToggleTrackMute}
+                  onToggleSolo={onToggleTrackSolo}
+                />
+
+                {onSetBPM && onResetTempo && (
+                  <TempoControl
+                    currentBPM={playbackState.currentBPM}
+                    originalTempo={playbackState.originalTempo}
+                    currentSpeed={playbackState.currentSpeed}
+                    onSetBPM={onSetBPM}
+                    onReset={onResetTempo}
+                  />
+                )}
+
+                <MetronomeIndicator currentBeat={playbackState.metronomeBeat} />
+              </>
+            )}
+          </ScrollableContainer>
+        </div>
+      )}
+
+      {/* Mobile: Non-GP metronome controls row */}
+      {isMobile &&
+        !isGuitarPro &&
+        metronomeState &&
+        onMetronomeBpmChange &&
+        onMetronomeToggle && (
+          <div className="flex items-center justify-center gap-2 px-3 py-2 border-t border-border/50 bg-card/80">
+            <div className="flex items-center gap-2 bg-muted rounded-lg p-1 border border-border">
+              <TooltipProvider delayDuration={100}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={onMetronomeToggle}
+                      className={cn(
+                        'p-2 rounded-md transition-colors',
+                        metronomeState.isActive
+                          ? 'bg-primary text-primary-foreground shadow-lg'
+                          : 'text-muted-foreground hover:bg-background hover:text-foreground'
+                      )}
+                      aria-label={metronomeState.isActive ? 'Stop metronome' : 'Start metronome'}
+                    >
+                      <Clock size={18} />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>{metronomeState.isActive ? 'Stop metronome' : 'Start metronome'}</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <input
+                type="range"
+                min="40"
+                max="220"
+                value={metronomeState.bpm}
+                onChange={e => onMetronomeBpmChange(parseInt(e.target.value))}
+                className="w-24 h-1 bg-border rounded-lg appearance-none cursor-pointer accent-primary"
+                aria-label="Metronome BPM"
+              />
+              <span className="text-xs font-mono w-10 text-center tabular-nums text-foreground">
+                {metronomeState.bpm}
+              </span>
+            </div>
+          </div>
+        )}
 
       {/* Progress bar row - only for GP */}
       {isGuitarPro && playbackState && playbackState.totalTime > 0 && onSeek && (

--- a/src/components/practice/TempoControl.tsx
+++ b/src/components/practice/TempoControl.tsx
@@ -72,7 +72,7 @@ export const TempoControl = memo(function TempoControl({
   );
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-1 sm:gap-2">
       <TooltipProvider delayDuration={100}>
         {/* BPM Display / Input */}
         <Tooltip>
@@ -81,13 +81,13 @@ export const TempoControl = memo(function TempoControl({
               type="button"
               onClick={handleStartEdit}
               className={cn(
-                'flex items-center gap-1.5 px-2 py-1 rounded',
+                'flex items-center gap-1 sm:gap-1.5 px-1.5 sm:px-2 py-1 rounded',
                 'bg-muted hover:bg-muted/80 transition-colors',
-                'cursor-pointer'
+                'cursor-pointer shrink-0'
               )}
               aria-label="Click to edit BPM"
             >
-              <Timer size={14} className="text-muted-foreground" />
+              <Timer size={14} className="text-muted-foreground hidden sm:block" />
               {isEditing ? (
                 <input
                   type="number"
@@ -117,7 +117,7 @@ export const TempoControl = memo(function TempoControl({
           </TooltipContent>
         </Tooltip>
 
-        {/* Reset Button */}
+        {/* Reset Button - icon only on mobile */}
         {isModified && (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -125,10 +125,10 @@ export const TempoControl = memo(function TempoControl({
                 variant="ghost"
                 size="sm"
                 onClick={onReset}
-                className="h-7 px-2 text-xs gap-1"
+                className="h-8 w-8 sm:h-7 sm:w-auto sm:px-2 p-0 text-xs gap-1 shrink-0"
               >
                 <RotateCcw size={12} />
-                Reset
+                <span className="hidden sm:inline">Reset</span>
               </Button>
             </TooltipTrigger>
             <TooltipContent>
@@ -137,8 +137,8 @@ export const TempoControl = memo(function TempoControl({
           </Tooltip>
         )}
 
-        {/* BPM Slider */}
-        <div className="flex items-center gap-2 bg-muted rounded px-2 py-1">
+        {/* BPM Slider - hidden on mobile to save space */}
+        <div className="hidden sm:flex items-center gap-2 bg-muted rounded px-2 py-1">
           <input
             type="range"
             min={minBPM}

--- a/src/components/practice/TrackSelector.tsx
+++ b/src/components/practice/TrackSelector.tsx
@@ -44,7 +44,7 @@ export const TrackSelector = memo(function TrackSelector({
               <Button
                 variant="outline"
                 size="sm"
-                className="h-8 gap-2 text-xs font-medium max-w-[140px]"
+                className="h-8 gap-1 sm:gap-2 text-xs font-medium max-w-[100px] sm:max-w-[140px] shrink-0"
                 data-testid="track-selector"
               >
                 <div


### PR DESCRIPTION
- Refactor PracticeControlBar with mobile-first two-row layout
- Transport controls (play/pause/stop/loop) now in dedicated row on mobile
- Add ScrollableContainer component with fade gradient overlays
- Chevron icons indicate scrollable content direction
- Secondary controls (tempo, track, metronome) scroll horizontally with fade hints
- Update PlaybackControls with consistent touch-friendly sizing (44px mobile)
- Make TempoControl compact on mobile (hide slider, icon-only reset button)
- Reduce TrackSelector max-width on mobile for better space usage