### PR TITLE
feat(security): add confirmation dialogs for destructive delete operations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -700,6 +700,7 @@ const App: React.FC = () => {
                     setSongs={setSongs}
                     onSelectSong={id => navigate(getSongDetailRoute(id))}
                     events={events}
+                    isAdmin={isAdmin}
                   />
                 }
               />

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -28,7 +28,7 @@ import {
   AvatarFallback,
   Badge,
 } from '@/components/primitives';
-import { toast, ConfirmDialog } from '@/components/ui';
+import { toast, ConfirmDialog, DangerousActionDialog } from '@/components/ui';
 import { StorageService } from '@/services/storageService';
 import { InvitationManager } from '@/components/InvitationManager';
 import { isSupabaseConfigured } from '@/services/supabaseClient';
@@ -102,6 +102,26 @@ export const Settings: React.FC<SettingsProps> = memo(function Settings({
   const closeDialog = useCallback(() => {
     setConfirmDialog(prev => ({ ...prev, isOpen: false }));
   }, []);
+
+  // --- Dangerous Action Dialog State (Delete All Data) ---
+  const [dangerDialogOpen, setDangerDialogOpen] = useState(false);
+
+  const openDangerDialog = useCallback(() => {
+    setDangerDialogOpen(true);
+  }, []);
+
+  const closeDangerDialog = useCallback(() => {
+    setDangerDialogOpen(false);
+  }, []);
+
+  const handleDeleteAllData = useCallback(() => {
+    setSongs?.([]);
+    setMembers([]);
+    setAvailableRoles([]);
+    setEvents?.([]);
+    setDangerDialogOpen(false);
+    toast.success('All data has been deleted');
+  }, [setSongs, setMembers, setAvailableRoles, setEvents]);
 
   // --- Member Handlers ---
   const handleAddMember = useCallback(() => {
@@ -494,6 +514,25 @@ export const Settings: React.FC<SettingsProps> = memo(function Settings({
               </div>
             </CardContent>
           </Card>
+
+          {/* Danger Zone - Admin Only */}
+          {isAdmin && (
+            <Card className="border-destructive bg-destructive/5">
+              <CardHeader>
+                <CardTitle className="font-serif text-destructive">Danger Zone</CardTitle>
+                <CardDescription>
+                  Permanently delete all band data including songs, members, roles, and events. This
+                  action cannot be undone.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button variant="destructive" onClick={openDangerDialog} className="gap-2">
+                  <Trash2 className="h-4 w-4" />
+                  Delete All Data
+                </Button>
+              </CardContent>
+            </Card>
+          )}
         </TabsContent>
       </Tabs>
 
@@ -507,6 +546,17 @@ export const Settings: React.FC<SettingsProps> = memo(function Settings({
         onCancel={closeDialog}
         confirmLabel="Confirm"
         cancelLabel="Cancel"
+      />
+
+      {/* Dangerous Action Dialog (Delete All Data) */}
+      <DangerousActionDialog
+        isOpen={dangerDialogOpen}
+        title="Delete All Data"
+        message="This will permanently delete all songs, members, roles, and events. This action cannot be undone."
+        confirmPhrase="DELETE ALL DATA"
+        confirmLabel="Delete Everything"
+        onConfirm={handleDeleteAllData}
+        onCancel={closeDangerDialog}
       />
     </div>
   );

--- a/src/components/setlist/SetlistItem.tsx
+++ b/src/components/setlist/SetlistItem.tsx
@@ -34,6 +34,8 @@ export interface SetlistItemProps {
   onDrop: (e: React.DragEvent<HTMLElement>) => void;
   /** Callback when drag ends */
   onDragEnd: () => void;
+  /** Whether the current user is a band admin (controls delete button visibility) */
+  isAdmin?: boolean;
 }
 
 // =============================================================================
@@ -60,6 +62,7 @@ export const SetlistItem = memo(function SetlistItem({
   onDragOver,
   onDrop,
   onDragEnd,
+  isAdmin = false,
 }: SetlistItemProps) {
   return (
     <li
@@ -125,27 +128,29 @@ export const SetlistItem = memo(function SetlistItem({
       {/* Status + Actions */}
       <div className="flex items-center gap-2 shrink-0">
         <StatusBadge status={song.status} />
-        <TooltipProvider delayDuration={100}>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={e => {
-                  e.stopPropagation();
-                  onDelete(song.id);
-                }}
-                className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
-                aria-label={`Delete ${song.title}`}
-              >
-                <Trash2 size={16} />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Remove from setlist</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        {isAdmin && (
+          <TooltipProvider delayDuration={100}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={e => {
+                    e.stopPropagation();
+                    onDelete(song.id);
+                  }}
+                  className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
+                  aria-label={`Delete ${song.title}`}
+                >
+                  <Trash2 size={16} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Delete Song</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
       </div>
     </li>
   );

--- a/src/components/ui/DangerousActionDialog.tsx
+++ b/src/components/ui/DangerousActionDialog.tsx
@@ -1,0 +1,139 @@
+import React, { memo, useCallback, useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+  Input,
+} from '@/components/primitives';
+import { cn } from '@/lib/utils';
+
+interface DangerousActionDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  /** The exact phrase user must type to confirm (case-sensitive) */
+  confirmPhrase: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /**
+   * Called when user confirms the action.
+   * Should be wrapped in useCallback in parent component for stable reference.
+   */
+  onConfirm: () => void;
+  /**
+   * Called when dialog is dismissed (Cancel button, ESC key, or overlay click).
+   * IMPORTANT: Must be wrapped in useCallback in parent component to prevent
+   * unnecessary re-renders, as this is a dependency of internal handleOpenChange.
+   */
+  onCancel: () => void;
+}
+
+/**
+ * DangerousActionDialog - Confirmation dialog requiring text input
+ *
+ * Used for high-risk operations like deleting all data.
+ * User must type the exact confirmPhrase to enable the confirm button.
+ */
+export const DangerousActionDialog: React.FC<DangerousActionDialogProps> = memo(
+  function DangerousActionDialog({
+    isOpen,
+    title,
+    message,
+    confirmPhrase,
+    confirmLabel = 'Delete',
+    cancelLabel = 'Cancel',
+    onConfirm,
+    onCancel,
+  }) {
+    const [inputValue, setInputValue] = useState('');
+
+    const isConfirmEnabled = inputValue.trim() === confirmPhrase;
+
+    // Handle dialog open state changes (e.g., ESC key, overlay click)
+    // Also resets input value when dialog closes
+    const handleOpenChange = useCallback(
+      (open: boolean) => {
+        if (!open) {
+          setInputValue('');
+          onCancel();
+        }
+      },
+      [onCancel]
+    );
+
+    const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+      setInputValue(e.target.value);
+    }, []);
+
+    const handleConfirm = useCallback(() => {
+      if (isConfirmEnabled) {
+        onConfirm();
+      }
+    }, [isConfirmEnabled, onConfirm]);
+
+    return (
+      <AlertDialog open={isOpen} onOpenChange={handleOpenChange}>
+        <AlertDialogContent className="max-w-md">
+          <AlertDialogHeader>
+            <div className="flex items-start gap-4">
+              <div
+                className={cn(
+                  'flex h-12 w-12 shrink-0 items-center justify-center rounded-full',
+                  'bg-destructive/20'
+                )}
+              >
+                <Trash2 className="h-6 w-6 text-destructive" />
+              </div>
+              <div className="flex flex-col gap-2">
+                <AlertDialogTitle>{title}</AlertDialogTitle>
+                <AlertDialogDescription>{message}</AlertDialogDescription>
+              </div>
+            </div>
+          </AlertDialogHeader>
+
+          <div className="mt-4 space-y-3">
+            <p className="text-sm text-muted-foreground">
+              To confirm, type{' '}
+              <code className="bg-muted px-1.5 py-0.5 rounded font-mono text-destructive font-semibold">
+                {confirmPhrase}
+              </code>{' '}
+              below:
+            </p>
+            <Input
+              value={inputValue}
+              onChange={handleInputChange}
+              placeholder={confirmPhrase}
+              className="font-mono"
+              autoComplete="off"
+              autoCorrect="off"
+              autoFocus
+              spellCheck={false}
+            />
+          </div>
+
+          <AlertDialogFooter className="mt-6">
+            <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirm}
+              disabled={!isConfirmEnabled}
+              className={cn(
+                'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+                !isConfirmEnabled && 'opacity-50'
+              )}
+            >
+              {confirmLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
+);
+
+DangerousActionDialog.displayName = 'DangerousActionDialog';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,6 +4,7 @@ export { LoadingSpinner } from './LoadingSpinner';
 export { LoadingScreen } from './LoadingScreen';
 export { EmptyState } from './EmptyState';
 export { ConfirmDialog } from './ConfirmDialog';
+export { DangerousActionDialog } from './DangerousActionDialog';
 export { ErrorBoundary } from './ErrorBoundary';
 export { ResizablePanel } from './ResizablePanel';
 


### PR DESCRIPTION
## Summary

- Add confirmation dialog for song deletion (admin-only visibility)
- Create `DangerousActionDialog` component requiring users to type "DELETE ALL DATA" to confirm
- Add "Danger Zone" section in Settings > DATA tab for deleting all band data
- Hide delete buttons from non-admin users

## Changes

| File | Description |
|------|-------------|
| `DangerousActionDialog.tsx` | New component for high-risk confirmations requiring typed phrase |
| `SetlistManager.tsx` | Added `isAdmin` prop and confirmation dialog for song deletion |
| `SetlistItem.tsx` | Added `isAdmin` prop; delete button hidden for non-admins |
| `Settings.tsx` | Added Danger Zone card with Delete All Data functionality |
| `App.tsx` | Pass `isAdmin` to `SetlistManager` |

## Test plan

- [ ] Verify song delete button is hidden for non-admin users
- [ ] Verify song delete shows confirmation dialog for admins
- [ ] Verify confirming song delete removes the song and all associated data
- [ ] Verify canceling/dismissing dialog does not delete
- [ ] Verify Delete All Data button is hidden for non-admin users
- [ ] Verify Delete All Data requires typing exact phrase "DELETE ALL DATA"
- [ ] Verify confirm button stays disabled until phrase matches exactly
- [ ] Verify confirming clears all data (songs, members, roles, events)
- [ ] Verify toast notification appears after successful deletion