### PR TITLE
fix(ci): update Claude workflow permissions for issue/PR management

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,10 +20,11 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
+      contents: write      # Required for Claude to push code changes
+      pull-requests: write # Required for Claude to create/modify PR descriptions and comments
+      issues: write        # Required for Claude to create/modify issues and issue comments
+      id-token: write      # Required for OIDC authentication with Anthropic
+      actions: read        # Required for Claude to read CI results on PRs
 
     steps:
       - name: Checkout repository
@@ -53,5 +54,5 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      contents: write      # Required for Claude to push code changes
+      pull-requests: write # Required for Claude to create/modify PR descriptions and comments
+      issues: write        # Required for Claude to create/modify issues and issue comments
+      id-token: write      # Required for OIDC authentication with Anthropic
+      actions: read        # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -40,11 +40,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
+          # Allow Claude to use gh CLI for GitHub operations (issues, PRs, comments)
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"'
 


### PR DESCRIPTION
Change permissions from 'read' to 'write' for contents, pull-requests,
and issues to enable Claude to:
- Create and modify issues
- Comment on issues and PRs
- Update PR descriptions
- Push code changes

Also simplify claude_args to use wildcard patterns (gh issue:*, gh pr:*)
for comprehensive gh CLI access.