### PR TITLE
fix(ci): remove invalid puppeteer plugin and claude_env parameters

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,13 +55,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--model claude-opus-4-5-20251101 --max-turns 25 --allowed-tools "Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"'
-
-          # Puppeteer for browser automation (requires TEST_EMAIL and TEST_PASSWORD secrets)
-          plugins: |
-            puppeteer
-
-          # Pass test credentials for app access
-          claude_env: |
-            TEST_EMAIL=${{ secrets.TEST_EMAIL }}
-            TEST_PASSWORD=${{ secrets.TEST_PASSWORD }}
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,13 +44,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--model claude-opus-4-5-20251101 --max-turns 30 --allowed-tools "Bash(gh issue:*),Bash(gh pr:*),Bash(gh search:*)"'
-
-          # Puppeteer for browser automation (requires TEST_EMAIL and TEST_PASSWORD secrets)
-          plugins: |
-            puppeteer
-
-          # Pass test credentials for app access
-          claude_env: |
-            TEST_EMAIL=${{ secrets.TEST_EMAIL }}
-            TEST_PASSWORD=${{ secrets.TEST_PASSWORD }}
-


### PR DESCRIPTION
The claude-code-action does not support:
- `plugins: puppeteer` - Puppeteer is an MCP server, not a plugin
- `claude_env` - This input parameter does not exist

These hallucinated parameters caused workflow failures with:
"Unexpected input(s) 'claude_env'" and "Failed to install plugin 'puppeteer'"