### PR TITLE
fix(ui): route dashboard practice buttons to specific songs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,13 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback, lazy, Suspense } from 'react';
-import { Routes, Route, Navigate, useNavigate, useParams, useLocation } from 'react-router-dom';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useNavigate,
+  useParams,
+  useLocation,
+  useSearchParams,
+} from 'react-router-dom';
 import { toast, LoadingScreen } from './components/ui';
 import { Session } from '@supabase/supabase-js';
 import {
@@ -91,14 +99,42 @@ const SongDetailRoute: React.FC = () => {
 };
 
 /**
- * Route wrapper component for PracticeRoom.
- * Provides song navigation callback using route constants.
+ * Route wrapper component for PracticeRoom with song-specific routing.
+ * Extracts songId from URL params (for /songs/:songId/practice route)
+ * and provides song navigation callback.
  */
 const PracticeRoomRoute: React.FC = () => {
   const navigate = useNavigate();
+  const { songId } = useParams<{ songId: string }>();
   const { songs } = useAppData();
 
-  return <PracticeRoom songs={songs} onNavigateToSong={id => navigate(getSongDetailRoute(id))} />;
+  return (
+    <PracticeRoom
+      songs={songs}
+      onNavigateToSong={id => navigate(getSongDetailRoute(id))}
+      initialSongId={songId}
+    />
+  );
+};
+
+/**
+ * Route wrapper component for PracticeRoom with query parameter support.
+ * Extracts songId from query params (for /practice?songId=xxx route)
+ * and provides song navigation callback.
+ */
+const PracticeRoomWithQueryParam: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { songs } = useAppData();
+  const initialSongId = searchParams.get('songId');
+
+  return (
+    <PracticeRoom
+      songs={songs}
+      onNavigateToSong={id => navigate(getSongDetailRoute(id))}
+      initialSongId={initialSongId}
+    />
+  );
 };
 
 /**
@@ -856,10 +892,7 @@ const App: React.FC = () => {
                   path={ROUTES.PRACTICE}
                   element={
                     <Suspense fallback={<LoadingScreen message="Loading Practice Room..." />}>
-                      <PracticeRoom
-                        songs={songs}
-                        onNavigateToSong={id => navigate(getSongDetailRoute(id))}
-                      />
+                      <PracticeRoomWithQueryParam />
                     </Suspense>
                   }
                 />

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -30,7 +30,7 @@ import {
   daysBetween,
   formatDaysUntil,
 } from '@/lib/dateUtils';
-import { ROUTES } from '@/routes';
+import { ROUTES, getPracticeRoute } from '@/routes';
 import type { Song, BandEvent, BandMember } from '@/types';
 
 // =============================================================================
@@ -672,7 +672,7 @@ export const Dashboard: React.FC<DashboardProps> = memo(function Dashboard({
                       )}
                       <Button
                         size="sm"
-                        onClick={() => navigate(ROUTES.PRACTICE)}
+                        onClick={() => navigate(getPracticeRoute(song.id))}
                         className="gap-1 h-7 px-2.5 text-xs"
                         aria-label={`Practice ${song.title}`}
                       >

--- a/src/components/PracticeRoom.tsx
+++ b/src/components/PracticeRoom.tsx
@@ -48,6 +48,8 @@ import { PracticeControlBar, type AlphaTabState, type TrackInfo } from './practi
 interface PracticeRoomProps {
   songs: Song[];
   onNavigateToSong?: (id: string) => void;
+  /** Optional song ID to preselect when the practice room loads */
+  initialSongId?: string | null;
 }
 
 // =============================================================================
@@ -123,16 +125,23 @@ SongListItem.displayName = 'SongListItem';
 // MAIN COMPONENT
 // =============================================================================
 
-export const PracticeRoom: React.FC<PracticeRoomProps> = memo(function PracticeRoom({ songs }) {
+export const PracticeRoom: React.FC<PracticeRoomProps> = memo(function PracticeRoom({
+  songs,
+  initialSongId,
+}) {
   const isMobile = useIsMobile();
 
   // ---------------------------------------------------------------------------
   // STATE
   // ---------------------------------------------------------------------------
 
-  const [selectedSongId, setSelectedSongId] = useState<string | null>(
-    songs.length > 0 ? songs[0].id : null
-  );
+  const [selectedSongId, setSelectedSongId] = useState<string | null>(() => {
+    // If initialSongId provided and exists in songs, use it; otherwise default to first song
+    if (initialSongId && songs.some(s => s.id === initialSongId)) {
+      return initialSongId;
+    }
+    return songs.length > 0 ? songs[0].id : null;
+  });
   const [playbackRate, setPlaybackRate] = useState(1.0);
   const [volume, setVolume] = useState(0.8);
   const [isPlaying, setIsPlaying] = useState(false);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -42,6 +42,14 @@ export const ROUTES = {
 export const getSongDetailRoute = (songId: string): string => `${ROUTES.SONG_DETAIL}/${songId}`;
 
 /**
+ * Helper to build practice route with optional song preselection
+ * @param songId - Optional song ID to preselect in the practice room
+ * @returns The practice route, with query param if songId provided
+ */
+export const getPracticeRoute = (songId?: string): string =>
+  songId ? `${ROUTES.PRACTICE}?songId=${songId}` : ROUTES.PRACTICE;
+
+/**
  * Navigation items configuration for the sidebar.
  * Maps route identifiers to their display properties.
  */


### PR DESCRIPTION
## Summary
- Dashboard Practice Queue buttons now navigate to the correct song in Practice Room
- Added `getPracticeRoute(songId?)` helper function for practice route generation
- Added `initialSongId` prop to PracticeRoom component for song preselection
- Uses query parameter approach (`/practice?songId=xxx`) for song preselection

Closes #86

## Test plan
- [ ] Click Practice on different songs in Dashboard Practice Queue
- [ ] Verify correct song is preselected in Practice Room sidebar
- [ ] Navigate directly to `/practice` - should show first song
- [ ] Navigate to `/practice?songId=invalid` - should gracefully show first song
- [ ] Verify existing `/songs/:songId/practice` route still works