### PR TITLE
feat(personalization): add Phase 3 user-member linking features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { Settings } from './components/Settings';
 import { BandDashboard } from './components/BandDashboard';
 import { ScheduleManager } from './components/ScheduleManager';
 import { PracticeHistory } from './components/PracticeHistory';
+import { MySongs } from './components/MySongs';
 import { Login } from './components/Login';
 import { Signup } from './components/Signup';
 import { PasswordReset } from './components/PasswordReset';
@@ -57,6 +58,7 @@ import { useLayoutShortcuts } from './hooks/useLayoutShortcuts';
 import { useBandCreation } from './hooks/useBandCreation';
 import { ThemeProvider } from './components/ui/ThemeProvider';
 import { SidebarProvider, AppShell } from './components/layout';
+import { useAllUserSongStatuses } from './hooks/useUserSongStatus';
 
 // Re-export useAppContext from contexts for backwards compatibility
 // Components importing from App.tsx will continue to work
@@ -192,6 +194,12 @@ const App: React.FC = () => {
   const [members, setMembers] = useState<BandMember[]>([]);
   const [availableRoles, setAvailableRoles] = useState<string[]>([]);
   const [events, setEvents] = useState<BandEvent[]>([]);
+
+  // -- User Song Statuses for personalized Dashboard --
+  const { statuses: userSongStatuses } = useAllUserSongStatuses(
+    session?.user?.id || null,
+    currentBandId
+  );
 
   // -- Auto-Save Configuration --
   const AUTOSAVE_DEBOUNCE_MS = 1000;
@@ -1108,6 +1116,7 @@ const App: React.FC = () => {
                       members={members}
                       onNavigateToSong={id => navigate(getSongDetailRoute(id))}
                       events={events}
+                      userSongStatuses={userSongStatuses}
                     />
                   }
                 />
@@ -1140,6 +1149,14 @@ const App: React.FC = () => {
                       songs={songs}
                       currentUserId={session?.user?.id || null}
                       currentBandId={currentBandId}
+                    />
+                  }
+                />
+                <Route
+                  path={ROUTES.MY_SONGS}
+                  element={
+                    <MySongs
+                      onNavigateToSong={id => navigate(getSongDetailRoute(id))}
                     />
                   }
                 />

--- a/src/components/LinkAccountSection.tsx
+++ b/src/components/LinkAccountSection.tsx
@@ -10,6 +10,7 @@ import {
   Avatar,
   AvatarFallback,
   Badge,
+  Label,
   Select,
   SelectContent,
   SelectItem,
@@ -20,23 +21,50 @@ import { toast, Alert, AlertTitle, AlertDescription } from '@/components/ui';
 import { useLinkedMember } from '@/hooks/useLinkedMember';
 import { claimMember } from '@/services/supabaseStorageService';
 import { getAvatarColor, getInitials } from '@/lib/avatar';
+import type { BandMember } from '@/types';
 
 interface LinkAccountSectionProps {
   currentBandId: string | undefined;
   currentUserId: string | undefined;
+  availableRoles: string[];
+  onUpdateMember: (member: BandMember) => void;
 }
 
 /**
  * LinkAccountSection component for claiming member records
  * Displays linked member or dropdown to claim unlinked members
+ * Also allows setting preferred instrument for GP track auto-selection
  */
 export const LinkAccountSection = memo(function LinkAccountSection({
   currentBandId,
   currentUserId,
+  availableRoles,
+  onUpdateMember,
 }: LinkAccountSectionProps) {
   const { linkedMember, unlinkedMembers, isLoading, error, refetch } = useLinkedMember(currentBandId || null);
   const [selectedMemberId, setSelectedMemberId] = useState<string>('');
   const [isClaiming, setIsClaiming] = useState(false);
+  const [isSavingPreference, setIsSavingPreference] = useState(false);
+
+  const handlePreferredInstrumentChange = async (value: string) => {
+    if (!linkedMember) return;
+
+    setIsSavingPreference(true);
+    try {
+      // value of '' means "None" was selected, convert to null
+      const preferredInstrument = value === '' ? null : value;
+      onUpdateMember({
+        ...linkedMember,
+        preferredInstrument,
+      });
+      toast.success('Preferred instrument saved');
+    } catch (err) {
+      console.error('Failed to save preferred instrument:', err);
+      toast.error('Failed to save preferred instrument');
+    } finally {
+      setIsSavingPreference(false);
+    }
+  };
 
   const handleClaimMember = async () => {
     if (!selectedMemberId || !currentBandId || !currentUserId) return;
@@ -114,21 +142,50 @@ export const LinkAccountSection = memo(function LinkAccountSection({
       </CardHeader>
       <CardContent>
         {linkedMember ? (
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Avatar className={getAvatarColor(linkedMember.avatarColor)}>
-                <AvatarFallback>{getInitials(linkedMember.name)}</AvatarFallback>
-              </Avatar>
-              <div>
-                <p className="font-medium">{linkedMember.name}</p>
-                <p className="text-sm text-muted-foreground">
-                  {linkedMember.roles.join(', ')}
-                </p>
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <Avatar className={getAvatarColor(linkedMember.avatarColor)}>
+                  <AvatarFallback>{getInitials(linkedMember.name)}</AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="font-medium">{linkedMember.name}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {linkedMember.roles.join(', ')}
+                  </p>
+                </div>
               </div>
+              <Badge variant="secondary" className="ml-auto">
+                Linked
+              </Badge>
             </div>
-            <Badge variant="secondary" className="ml-auto">
-              Linked
-            </Badge>
+
+            {/* Preferred Instrument Selector */}
+            <div className="pt-4 border-t border-border">
+              <Label htmlFor="preferred-instrument" className="text-sm font-medium">
+                Preferred Instrument
+              </Label>
+              <Select
+                value={linkedMember.preferredInstrument || ''}
+                onValueChange={handlePreferredInstrumentChange}
+                disabled={isSavingPreference}
+              >
+                <SelectTrigger id="preferred-instrument" className="mt-1.5">
+                  <SelectValue placeholder="Select your instrument..." />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">None</SelectItem>
+                  {availableRoles.map(role => (
+                    <SelectItem key={role} value={role}>
+                      {role}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground mt-1">
+                Auto-selects matching track when opening Guitar Pro files
+              </p>
+            </div>
           </div>
         ) : unlinkedMembers.length > 0 ? (
           <div className="space-y-4">

--- a/src/components/MySongs.tsx
+++ b/src/components/MySongs.tsx
@@ -1,0 +1,286 @@
+import React, { memo, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Music, Play, User } from 'lucide-react';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+} from '@/components/primitives';
+import { EmptyState, StatusBadge } from '@/components/ui';
+import { cn } from '@/lib/utils';
+import { getPracticeRoute } from '@/routes';
+import { useLinkedMember } from '@/hooks/useLinkedMember';
+import { useAllUserSongStatuses } from '@/hooks/useUserSongStatus';
+import { useAppActions, useAppData } from '@/contexts';
+import type { Song, UserSongProgress } from '@/types';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+interface MySongsProps {
+  onNavigateToSong: (songId: string) => void;
+}
+
+interface SongWithStatus {
+  song: Song;
+  userStatus: UserSongProgress | undefined;
+}
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+const USER_STATUS_LABELS: Record<string, { label: string; className: string }> = {
+  'Not Started': { label: 'Not Started', className: 'bg-muted text-muted-foreground' },
+  'Learning': { label: 'Learning', className: 'bg-info/20 text-info' },
+  'Learned': { label: 'Learned', className: 'bg-success/20 text-success' },
+  'Mastered': { label: 'Mastered', className: 'bg-primary/20 text-primary' },
+};
+
+// =============================================================================
+// SUB-COMPONENTS
+// =============================================================================
+
+interface SongRowProps {
+  song: Song;
+  userStatus: UserSongProgress | undefined;
+  onNavigateToSong: (id: string) => void;
+  onPractice: (id: string) => void;
+}
+
+const SongRow = memo(function SongRow({
+  song,
+  userStatus,
+  onNavigateToSong,
+  onPractice,
+}: SongRowProps) {
+  const statusConfig = userStatus?.status
+    ? USER_STATUS_LABELS[userStatus.status]
+    : USER_STATUS_LABELS['Not Started'];
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-4 px-4 py-3',
+        'border-b border-border/30 last:border-b-0',
+        'hover:bg-muted/30 transition-colors'
+      )}
+    >
+      {/* Song info */}
+      <div className="flex-1 min-w-0">
+        <button
+          type="button"
+          onClick={() => onNavigateToSong(song.id)}
+          className="text-left hover:text-primary transition-colors"
+        >
+          <p className="font-semibold text-foreground truncate">{song.title}</p>
+          <p className="text-sm text-muted-foreground truncate">{song.artist}</p>
+        </button>
+      </div>
+
+      {/* Status badges */}
+      <div className="flex items-center gap-2 shrink-0">
+        <StatusBadge status={song.status} />
+        <span
+          className={cn(
+            'px-2 py-0.5 rounded-full text-xs font-medium',
+            statusConfig.className
+          )}
+        >
+          {statusConfig.label}
+        </span>
+      </div>
+
+      {/* Practice button */}
+      <Button
+        size="sm"
+        onClick={() => onPractice(song.id)}
+        className="gap-1 h-8 px-3"
+        aria-label={`Practice ${song.title}`}
+      >
+        <Play size={14} />
+        Practice
+      </Button>
+    </div>
+  );
+});
+
+SongRow.displayName = 'SongRow';
+
+// =============================================================================
+// MAIN COMPONENT
+// =============================================================================
+
+export const MySongs: React.FC<MySongsProps> = memo(function MySongs({
+  onNavigateToSong,
+}) {
+  const navigate = useNavigate();
+  const { currentBandId, session } = useAppActions();
+  const { songs } = useAppData();
+  const { linkedMember } = useLinkedMember(currentBandId);
+  const { statuses: userSongStatuses } = useAllUserSongStatuses(
+    session?.user?.id || null,
+    currentBandId
+  );
+
+  // Filter songs assigned to the current user's linked member
+  const mySongs = useMemo<SongWithStatus[]>(() => {
+    if (!linkedMember) return [];
+
+    return songs
+      .filter(song =>
+        song.assignments.some(a => a.memberId === linkedMember.id)
+      )
+      .map(song => ({
+        song,
+        userStatus: userSongStatuses.get(song.id),
+      }));
+  }, [songs, linkedMember, userSongStatuses]);
+
+  // Group songs by user learning status
+  const groupedSongs = useMemo(() => {
+    const notStarted: SongWithStatus[] = [];
+    const learning: SongWithStatus[] = [];
+    const learned: SongWithStatus[] = [];
+    const mastered: SongWithStatus[] = [];
+
+    for (const item of mySongs) {
+      const status = item.userStatus?.status || 'Not Started';
+      switch (status) {
+        case 'Not Started':
+          notStarted.push(item);
+          break;
+        case 'Learning':
+          learning.push(item);
+          break;
+        case 'Learned':
+          learned.push(item);
+          break;
+        case 'Mastered':
+          mastered.push(item);
+          break;
+      }
+    }
+
+    return { notStarted, learning, learned, mastered };
+  }, [mySongs]);
+
+  const handlePractice = useCallback(
+    (songId: string) => {
+      navigate(getPracticeRoute(songId));
+    },
+    [navigate]
+  );
+
+  // ---------------------------------------------------------------------------
+  // RENDER: Not linked state
+  // ---------------------------------------------------------------------------
+
+  if (!linkedMember) {
+    return (
+      <div className="p-4 sm:p-6 lg:p-10">
+        <header className="mb-8">
+          <h2 className="text-4xl font-bold font-serif text-foreground tracking-tight">
+            My Songs
+          </h2>
+          <p className="text-muted-foreground mt-2">Songs assigned to you</p>
+        </header>
+
+        <Card>
+          <CardContent className="p-8">
+            <EmptyState
+              icon={User}
+              title="Link your account first"
+              description="Go to Settings > Team to link your account to a band member. Then you'll see songs assigned to you here."
+            />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // RENDER: No songs assigned
+  // ---------------------------------------------------------------------------
+
+  if (mySongs.length === 0) {
+    return (
+      <div className="p-4 sm:p-6 lg:p-10">
+        <header className="mb-8">
+          <h2 className="text-4xl font-bold font-serif text-foreground tracking-tight">
+            My Songs
+          </h2>
+          <p className="text-muted-foreground mt-2">
+            Songs assigned to <span className="font-medium text-foreground">{linkedMember.name}</span>
+          </p>
+        </header>
+
+        <Card>
+          <CardContent className="p-8">
+            <EmptyState
+              icon={Music}
+              title="No songs assigned"
+              description="You don't have any songs assigned to you yet. Ask your band admin to assign you to some songs."
+            />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // RENDER: Main view
+  // ---------------------------------------------------------------------------
+
+  const renderSection = (title: string, items: SongWithStatus[], defaultOpen = true) => {
+    if (items.length === 0) return null;
+
+    return (
+      <Card className="overflow-hidden">
+        <CardHeader className="py-3 px-4 bg-muted/30">
+          <div className="flex items-center justify-between">
+            <h3 className="font-semibold text-foreground">{title}</h3>
+            <span className="text-sm text-muted-foreground">{items.length} songs</span>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {(defaultOpen ? items : items.slice(0, 5)).map(({ song, userStatus }) => (
+            <SongRow
+              key={song.id}
+              song={song}
+              userStatus={userStatus}
+              onNavigateToSong={onNavigateToSong}
+              onPractice={handlePractice}
+            />
+          ))}
+        </CardContent>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-10 space-y-6">
+      <header>
+        <h2 className="text-4xl font-bold font-serif text-foreground tracking-tight">
+          My Songs
+        </h2>
+        <p className="text-muted-foreground mt-2">
+          {mySongs.length} songs assigned to{' '}
+          <span className="font-medium text-foreground">{linkedMember.name}</span>
+        </p>
+      </header>
+
+      {/* Priority: Not Started and Learning first */}
+      <div className="space-y-4">
+        {renderSection('Not Started', groupedSongs.notStarted)}
+        {renderSection('Learning', groupedSongs.learning)}
+        {renderSection('Learned', groupedSongs.learned)}
+        {renderSection('Mastered', groupedSongs.mastered)}
+      </div>
+    </div>
+  );
+});
+
+MySongs.displayName = 'MySongs';

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -31,6 +31,7 @@ interface NavigationProps {
 type NavItemId = (typeof NAV_ITEMS)[number]['id'];
 const iconMap: Record<NavItemId, LucideIcon> = {
   DASHBOARD: LayoutDashboard,
+  MY_SONGS: Music,
   PRACTICE: Mic2,
   PRACTICE_HISTORY: History,
   SETLIST: ListMusic,

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -464,7 +464,16 @@ export const Settings: React.FC<SettingsProps> = memo(function Settings({
         {/* Team Tab - Only rendered when Supabase is configured */}
         {showInvitations && currentBandId && currentUserId && (
           <TabsContent value="TEAM" className="space-y-6 animate-slide-in-from-bottom animation-forwards">
-            <LinkAccountSection currentBandId={currentBandId} currentUserId={currentUserId} />
+            <LinkAccountSection
+              currentBandId={currentBandId}
+              currentUserId={currentUserId}
+              availableRoles={availableRoles}
+              onUpdateMember={(updatedMember) => {
+                setMembers(prevMembers =>
+                  prevMembers.map(m => m.id === updatedMember.id ? updatedMember : m)
+                );
+              }}
+            />
 
             <Card>
               <CardContent className="p-6">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -29,6 +29,7 @@ import { ROUTES, NAV_ITEMS, matchRoute } from '@/routes';
 type NavItemId = (typeof NAV_ITEMS)[number]['id'];
 const iconMap: Record<NavItemId, LucideIcon> = {
   DASHBOARD: LayoutDashboard,
+  MY_SONGS: Music,
   PRACTICE: Mic2,
   PRACTICE_HISTORY: History,
   SETLIST: ListMusic,

--- a/src/lib/trackMatcher.test.ts
+++ b/src/lib/trackMatcher.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+import { findMatchingTrackIndex } from './trackMatcher';
+import type { TrackInfo } from '@/components/AlphaTabRenderer';
+
+/**
+ * Helper to create TrackInfo objects for tests
+ */
+const createTrack = (name: string, index: number = 0): TrackInfo => ({
+  index,
+  name,
+  isMute: false,
+  isSolo: false,
+  volume: 1.0,
+});
+
+describe('findMatchingTrackIndex', () => {
+  describe('returns null for invalid inputs', () => {
+    it('returns null when preferredInstrument is null', () => {
+      const tracks = [createTrack('Lead Guitar', 0)];
+      expect(findMatchingTrackIndex(tracks, null)).toBeNull();
+    });
+
+    it('returns null when preferredInstrument is undefined', () => {
+      const tracks = [createTrack('Lead Guitar', 0)];
+      expect(findMatchingTrackIndex(tracks, undefined)).toBeNull();
+    });
+
+    it('returns null when preferredInstrument is empty string', () => {
+      const tracks = [createTrack('Lead Guitar', 0)];
+      expect(findMatchingTrackIndex(tracks, '')).toBeNull();
+    });
+
+    it('returns null when tracks array is empty', () => {
+      expect(findMatchingTrackIndex([], 'Lead Guitar')).toBeNull();
+    });
+  });
+
+  describe('matches Lead Guitar', () => {
+    it('matches track named "Lead"', () => {
+      const tracks = [createTrack('Bass', 0), createTrack('Lead', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Guitar')).toBe(1);
+    });
+
+    it('matches track named "Guitar 1"', () => {
+      const tracks = [createTrack('Drums', 0), createTrack('Guitar 1', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Guitar')).toBe(1);
+    });
+
+    it('matches track named "Gtr 1"', () => {
+      const tracks = [createTrack('Bass', 0), createTrack('Gtr 1', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Guitar')).toBe(1);
+    });
+
+    it('matches track named "Electric Guitar"', () => {
+      const tracks = [createTrack('Electric Guitar', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Guitar')).toBe(0);
+    });
+
+    it('matches track named "Acoustic Guitar"', () => {
+      const tracks = [createTrack('Acoustic Guitar', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Guitar')).toBe(0);
+    });
+  });
+
+  describe('matches Rhythm Guitar', () => {
+    it('matches track named "Rhythm"', () => {
+      const tracks = [createTrack('Lead', 0), createTrack('Rhythm', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Rhythm Guitar')).toBe(1);
+    });
+
+    it('matches track named "Guitar 2"', () => {
+      const tracks = [createTrack('Guitar 1', 0), createTrack('Guitar 2', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Rhythm Guitar')).toBe(1);
+    });
+
+    it('falls back to generic guitar match when no rhythm pattern found', () => {
+      const tracks = [createTrack('Guitar Track', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Rhythm Guitar')).toBe(0);
+    });
+  });
+
+  describe('matches Bass Guitar', () => {
+    it('matches track named "Bass"', () => {
+      const tracks = [createTrack('Lead', 0), createTrack('Bass', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Bass Guitar')).toBe(1);
+    });
+
+    it('matches track containing "bass"', () => {
+      const tracks = [createTrack('Electric Bass', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Bass Guitar')).toBe(0);
+    });
+  });
+
+  describe('matches Drums', () => {
+    it('matches track named "Drums"', () => {
+      const tracks = [createTrack('Guitar', 0), createTrack('Drums', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Drums')).toBe(1);
+    });
+
+    it('matches track named "Drum Kit"', () => {
+      const tracks = [createTrack('Drum Kit', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Drums')).toBe(0);
+    });
+
+    it('matches track named "Percussion"', () => {
+      const tracks = [createTrack('Percussion', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Drums')).toBe(0);
+    });
+  });
+
+  describe('matches Synthesizer', () => {
+    it('matches track containing "synth"', () => {
+      const tracks = [createTrack('Guitar', 0), createTrack('Synth Pad', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Synthesizer')).toBe(1);
+    });
+
+    it('matches track containing "key"', () => {
+      const tracks = [createTrack('Keys', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Synthesizer')).toBe(0);
+    });
+
+    it('matches track containing "piano"', () => {
+      const tracks = [createTrack('Piano', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Synthesizer')).toBe(0);
+    });
+
+    it('matches track containing "organ"', () => {
+      const tracks = [createTrack('Hammond Organ', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Synthesizer')).toBe(0);
+    });
+  });
+
+  describe('matches Lead Vocals', () => {
+    it('matches track containing "vocal"', () => {
+      const tracks = [createTrack('Lead Vocal', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Vocals')).toBe(0);
+    });
+
+    it('matches track containing "voice"', () => {
+      const tracks = [createTrack('Voice', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Vocals')).toBe(0);
+    });
+
+    it('matches track containing "vox"', () => {
+      const tracks = [createTrack('Vox', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Vocals')).toBe(0);
+    });
+  });
+
+  describe('matches Backing Vocals', () => {
+    it('matches track containing "backing"', () => {
+      const tracks = [createTrack('Lead Vocal', 0), createTrack('Backing Vocals', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Backing Vocals')).toBe(1);
+    });
+
+    it('matches track containing "harmony"', () => {
+      const tracks = [createTrack('Harmony', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Backing Vocals')).toBe(0);
+    });
+
+    it('matches track containing "bgv"', () => {
+      const tracks = [createTrack('BGV', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Backing Vocals')).toBe(0);
+    });
+  });
+
+  describe('case insensitive matching', () => {
+    it('matches regardless of track name case', () => {
+      const tracks = [createTrack('BASS', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Bass Guitar')).toBe(0);
+    });
+
+    it('matches mixed case track names', () => {
+      const tracks = [createTrack('LeAd GuItAr', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Lead Guitar')).toBe(0);
+    });
+  });
+
+  describe('fallback matching', () => {
+    it('uses substring match for unknown instruments', () => {
+      const tracks = [createTrack('Violin', 0), createTrack('Cello', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Violin')).toBe(0);
+    });
+
+    it('uses substring match for custom instrument names', () => {
+      const tracks = [createTrack('Mandolin', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Mandolin')).toBe(0);
+    });
+
+    it('tries generic guitar match for guitar instruments without specific match', () => {
+      const tracks = [createTrack('Guitar', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Slide Guitar')).toBe(0);
+    });
+
+    it('tries generic gtr match for guitar instruments', () => {
+      const tracks = [createTrack('Gtr', 0)];
+      expect(findMatchingTrackIndex(tracks, 'Classical Guitar')).toBe(0);
+    });
+  });
+
+  describe('returns null when no match', () => {
+    it('returns null when instrument not found', () => {
+      const tracks = [createTrack('Piano', 0), createTrack('Strings', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Bass Guitar')).toBeNull();
+    });
+
+    it('returns null for non-guitar instrument with no patterns', () => {
+      const tracks = [createTrack('Guitar', 0), createTrack('Bass', 1)];
+      expect(findMatchingTrackIndex(tracks, 'Saxophone')).toBeNull();
+    });
+  });
+
+  describe('returns first match when multiple matches exist', () => {
+    it('returns first matching track index', () => {
+      const tracks = [
+        createTrack('Lead 1', 0),
+        createTrack('Lead 2', 1),
+        createTrack('Lead 3', 2),
+      ];
+      expect(findMatchingTrackIndex(tracks, 'Lead Guitar')).toBe(0);
+    });
+  });
+});

--- a/src/lib/trackMatcher.ts
+++ b/src/lib/trackMatcher.ts
@@ -1,0 +1,74 @@
+/**
+ * Track matching utility for auto-selecting Guitar Pro tracks
+ * based on user's preferred instrument setting.
+ */
+
+import type { TrackInfo } from '@/components/AlphaTabRenderer';
+
+/**
+ * Search patterns for matching role names to GP track names.
+ * Keys are Band Assist role names, values are lowercase search terms.
+ * Order matters - more specific patterns should come first.
+ */
+const INSTRUMENT_PATTERNS: Record<string, string[]> = {
+  'Lead Guitar': ['lead', 'guitar 1', 'gtr 1', 'electric guitar', 'acoustic guitar'],
+  'Rhythm Guitar': ['rhythm', 'guitar 2', 'gtr 2'],
+  'Bass Guitar': ['bass'],
+  'Drums': ['drum', 'percussion', 'beat'],
+  'Synthesizer': ['synth', 'key', 'piano', 'organ'],
+  'Lead Vocals': ['vocal', 'voice', 'vox'],
+  'Backing Vocals': ['backing', 'harmony', 'bgv'],
+};
+
+/**
+ * Find track index matching user's preferred instrument.
+ *
+ * Matching strategy:
+ * 1. Try known instrument patterns from INSTRUMENT_PATTERNS
+ * 2. Fall back to direct substring match on instrument name
+ * 3. For guitar instruments, try generic "guitar" or "gtr" match
+ *
+ * @param tracks - Available tracks from the Guitar Pro file
+ * @param preferredInstrument - User's preferred instrument setting
+ * @returns Track index if match found, null otherwise
+ *
+ * @example
+ * ```ts
+ * const tracks = [{ index: 0, name: 'Bass' }, { index: 1, name: 'Lead Guitar' }];
+ * findMatchingTrackIndex(tracks, 'Lead Guitar'); // 1
+ * findMatchingTrackIndex(tracks, 'Bass Guitar'); // 0
+ * findMatchingTrackIndex(tracks, 'Drums'); // null
+ * ```
+ */
+export function findMatchingTrackIndex(
+  tracks: TrackInfo[],
+  preferredInstrument: string | null | undefined
+): number | null {
+  if (!preferredInstrument || tracks.length === 0) return null;
+
+  const patterns = INSTRUMENT_PATTERNS[preferredInstrument];
+  const lowerTrackNames = tracks.map(t => t.name.toLowerCase());
+
+  // Strategy 1: Use known patterns if available
+  if (patterns) {
+    for (const pattern of patterns) {
+      const idx = lowerTrackNames.findIndex(name => name.includes(pattern));
+      if (idx !== -1) return idx;
+    }
+  }
+
+  // Strategy 2: Try direct substring match on instrument name
+  const lowerPref = preferredInstrument.toLowerCase();
+  const directMatchIdx = lowerTrackNames.findIndex(name => name.includes(lowerPref));
+  if (directMatchIdx !== -1) return directMatchIdx;
+
+  // Strategy 3: Try generic "guitar" match for guitar instruments
+  if (lowerPref.includes('guitar')) {
+    const guitarIdx = lowerTrackNames.findIndex(
+      name => name.includes('guitar') || name.includes('gtr')
+    );
+    if (guitarIdx !== -1) return guitarIdx;
+  }
+
+  return null;
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,6 +18,8 @@ export const ROUTES = {
   PRACTICE: '/practice',
   /** Practice history page */
   PRACTICE_HISTORY: '/practice-history',
+  /** My songs page - songs assigned to current user */
+  MY_SONGS: '/my-songs',
   /** Schedule/events page */
   SCHEDULE: '/schedule',
   /** Band lineup/dashboard page */
@@ -57,6 +59,7 @@ export const getPracticeRoute = (songId?: string): string =>
  */
 export const NAV_ITEMS = [
   { id: 'DASHBOARD', path: ROUTES.DASHBOARD, label: 'Dashboard' },
+  { id: 'MY_SONGS', path: ROUTES.MY_SONGS, label: 'My Songs' },
   { id: 'PRACTICE', path: ROUTES.PRACTICE, label: 'Practice Room' },
   { id: 'PRACTICE_HISTORY', path: ROUTES.PRACTICE_HISTORY, label: 'Practice History' },
   { id: 'SETLIST', path: ROUTES.SETLIST, label: 'Setlist Builder' },

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface BandMember {
   roles: string[]; // Default/Preferred roles (e.g. ["Lead Guitar", "Vocals"])
   avatarColor?: AvatarColorClass; // Validated avatar background color
   userId?: string | null; // Link to auth.users for personalized features
+  preferredInstrument?: string | null; // For auto-selecting GP tracks (e.g., "Lead Guitar")
 }
 
 // Type guard to check if member is linked to a user

--- a/supabase/migrations/022_add_preferred_instrument.sql
+++ b/supabase/migrations/022_add_preferred_instrument.sql
@@ -1,0 +1,9 @@
+-- Migration: 022_add_preferred_instrument
+-- Add preferred_instrument column to band_members table
+-- This allows users to auto-select their preferred track when opening Guitar Pro files
+
+-- Add preferred_instrument column to band_members
+ALTER TABLE band_members ADD COLUMN preferred_instrument TEXT;
+
+-- Comment for documentation
+COMMENT ON COLUMN band_members.preferred_instrument IS 'User preferred instrument for auto-selecting GP tracks (e.g., "Lead Guitar", "Bass Guitar")';


### PR DESCRIPTION
## Summary
- Add preferred instrument setting for auto-selecting Guitar Pro tracks
- Create "My Songs" view showing songs assigned to the current user
- Extend Dashboard urgency calculation to include user's learning status
- Add track matcher utility with fuzzy matching for GP track names

## Changes
- **New files**: MySongs.tsx, trackMatcher.ts, trackMatcher.test.ts, migration (022_add_preferred_instrument.sql)
- **Modified**: App.tsx, Dashboard.tsx, LinkAccountSection.tsx, Navigation.tsx, PracticeRoom.tsx, Settings.tsx, SongDetail.tsx, Sidebar.tsx, supabaseStorageService.ts, routes.ts, types.ts

## Test Plan
- [ ] Set preferred instrument in Settings > Team
- [ ] Open a GP file and verify matching track is auto-selected
- [ ] Navigate to My Songs and verify only assigned songs appear
- [ ] Check Dashboard Practice Queue shows personalized urgency
- [ ] All tests pass: `npm test`
- [ ] TypeScript checks pass: `npm run typecheck`
- [ ] Linting passes: `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "My Songs" view displaying songs assigned to you, grouped by learning status (Not Started, Learning, Learned, Mastered)
  * Band members can now set their preferred instrument in Settings
  * Guitar Pro files automatically select the matching instrument track for seamless practice
  * Dashboard now personalizes song urgency recommendations based on your individual learning progress

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->