### PR TITLE
fix(practice-modal): improve scrolling, keyboard submit, and date field responsiveness (#173)

### DIFF
--- a/src/hooks/useKeyboardSubmit.test.ts
+++ b/src/hooks/useKeyboardSubmit.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useKeyboardSubmit, isMacPlatform, getSubmitShortcutHint } from './useKeyboardSubmit';
+
+type EventListenerCall = [string, EventListenerOrEventListenerObject, ...unknown[]];
+
+// Helper to find keydown handler from spy calls
+function findKeydownHandler(
+  spy: ReturnType<typeof vi.spyOn>
+): EventListener | undefined {
+  const calls = spy.mock.calls as EventListenerCall[];
+  const call = calls.find((c) => c[0] === 'keydown');
+  return call?.[1] as EventListener | undefined;
+}
+
+// Helper to find the latest keydown handler (after rerenders)
+function findLatestKeydownHandler(
+  spy: ReturnType<typeof vi.spyOn>
+): EventListener | undefined {
+  const calls = spy.mock.calls as EventListenerCall[];
+  const keydownCalls = calls.filter((c) => c[0] === 'keydown');
+  const lastCall = keydownCalls[keydownCalls.length - 1];
+  return lastCall?.[1] as EventListener | undefined;
+}
+
+// Helper to count keydown listener calls
+function countKeydownCalls(spy: ReturnType<typeof vi.spyOn>): number {
+  const calls = spy.mock.calls as EventListenerCall[];
+  return calls.filter((c) => c[0] === 'keydown').length;
+}
+
+describe('useKeyboardSubmit', () => {
+  let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
+  let removeEventListenerSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+    removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should call onSubmit when Cmd+Enter is pressed', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useKeyboardSubmit({ onSubmit }));
+
+    // Get the registered keydown handler
+    const keydownHandler = findKeydownHandler(addEventListenerSpy);
+
+    expect(keydownHandler).toBeDefined();
+
+    // Simulate Cmd+Enter (Mac)
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      metaKey: true,
+      bubbles: true,
+    });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+    keydownHandler!(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onSubmit when Ctrl+Enter is pressed', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useKeyboardSubmit({ onSubmit }));
+
+    const keydownHandler = findKeydownHandler(addEventListenerSpy);
+
+    // Simulate Ctrl+Enter (Windows/Linux)
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      ctrlKey: true,
+      bubbles: true,
+    });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+
+    keydownHandler!(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call onSubmit when just Enter is pressed', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useKeyboardSubmit({ onSubmit }));
+
+    const keydownHandler = findKeydownHandler(addEventListenerSpy);
+
+    // Simulate just Enter without modifier
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+    });
+
+    keydownHandler!(event);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should not call onSubmit when enabled is false', () => {
+    const onSubmit = vi.fn();
+    renderHook(() => useKeyboardSubmit({ enabled: false, onSubmit }));
+
+    // When disabled, no event listener should be added
+    expect(countKeydownCalls(addEventListenerSpy)).toBe(0);
+  });
+
+  it('should remove event listener on unmount', () => {
+    const onSubmit = vi.fn();
+    const { unmount } = renderHook(() => useKeyboardSubmit({ onSubmit }));
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      'keydown',
+      expect.any(Function)
+    );
+  });
+
+  it('should update handler when onSubmit changes', () => {
+    const onSubmit1 = vi.fn();
+    const onSubmit2 = vi.fn();
+    const { rerender } = renderHook(
+      ({ onSubmit }) => useKeyboardSubmit({ onSubmit }),
+      { initialProps: { onSubmit: onSubmit1 } }
+    );
+
+    rerender({ onSubmit: onSubmit2 });
+
+    // Get the latest registered handler
+    const keydownHandler = findLatestKeydownHandler(addEventListenerSpy);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      metaKey: true,
+      bubbles: true,
+    });
+
+    keydownHandler!(event);
+
+    expect(onSubmit2).toHaveBeenCalledTimes(1);
+    expect(onSubmit1).not.toHaveBeenCalled();
+  });
+});
+
+describe('isMacPlatform', () => {
+  const originalNavigator = global.navigator;
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+    });
+  });
+
+  it('should return true for Mac platform', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { platform: 'MacIntel', userAgent: '' },
+      configurable: true,
+    });
+
+    expect(isMacPlatform()).toBe(true);
+  });
+
+  it('should return true for Mac userAgent when platform is not available', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { platform: '', userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' },
+      configurable: true,
+    });
+
+    expect(isMacPlatform()).toBe(true);
+  });
+
+  it('should return false for Windows platform', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { platform: 'Win32', userAgent: '' },
+      configurable: true,
+    });
+
+    expect(isMacPlatform()).toBe(false);
+  });
+
+  it('should return false for Linux platform', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { platform: 'Linux x86_64', userAgent: '' },
+      configurable: true,
+    });
+
+    expect(isMacPlatform()).toBe(false);
+  });
+});
+
+describe('getSubmitShortcutHint', () => {
+  const originalNavigator = global.navigator;
+
+  afterEach(() => {
+    Object.defineProperty(global, 'navigator', {
+      value: originalNavigator,
+      configurable: true,
+    });
+  });
+
+  it('should return Mac shortcut hint on Mac', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { platform: 'MacIntel', userAgent: '' },
+      configurable: true,
+    });
+
+    expect(getSubmitShortcutHint()).toBe('⌘↵');
+  });
+
+  it('should return Windows/Linux shortcut hint on non-Mac platforms', () => {
+    Object.defineProperty(global, 'navigator', {
+      value: { platform: 'Win32', userAgent: '' },
+      configurable: true,
+    });
+
+    expect(getSubmitShortcutHint()).toBe('Ctrl+↵');
+  });
+});

--- a/src/hooks/useKeyboardSubmit.ts
+++ b/src/hooks/useKeyboardSubmit.ts
@@ -1,0 +1,68 @@
+import { useEffect, useCallback } from 'react';
+
+/**
+ * Detects if the current platform is macOS.
+ * Uses navigator.platform with fallback to navigator.userAgent.
+ */
+export function isMacPlatform(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  // navigator.platform is deprecated but still widely supported
+  // Fall back to userAgent for newer browsers
+  return (
+    navigator.platform?.toLowerCase().includes('mac') ||
+    navigator.userAgent?.toLowerCase().includes('mac')
+  );
+}
+
+/**
+ * Returns the keyboard shortcut hint text for the current platform.
+ * Mac: ⌘↵
+ * Windows/Linux: Ctrl+↵
+ */
+export function getSubmitShortcutHint(): string {
+  return isMacPlatform() ? '⌘↵' : 'Ctrl+↵';
+}
+
+interface UseKeyboardSubmitOptions {
+  /** Whether the keyboard shortcut is enabled */
+  enabled?: boolean;
+  /** Callback to invoke on Cmd/Ctrl+Enter */
+  onSubmit: () => void;
+}
+
+/**
+ * Hook that listens for Cmd+Enter (Mac) or Ctrl+Enter (Windows/Linux)
+ * and invokes the onSubmit callback.
+ *
+ * @example
+ * ```tsx
+ * useKeyboardSubmit({
+ *   enabled: !isSubmitting,
+ *   onSubmit: () => formRef.current?.requestSubmit(),
+ * });
+ * ```
+ */
+export function useKeyboardSubmit({ enabled = true, onSubmit }: UseKeyboardSubmitOptions): void {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!enabled) return;
+
+      // Cmd+Enter on Mac, Ctrl+Enter on Windows/Linux
+      const isModifierPressed = e.metaKey || e.ctrlKey;
+      const isEnter = e.key === 'Enter';
+
+      if (isModifierPressed && isEnter) {
+        e.preventDefault();
+        onSubmit();
+      }
+    },
+    [enabled, onSubmit]
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [enabled, handleKeyDown]);
+}


### PR DESCRIPTION
## Summary

Fixes issue #173 by implementing three key UX improvements to the Log Practice Modal:

1. **Modal Scroll Issue Fixed** - Added `max-h-[90vh] overflow-y-auto` to DialogContent to enable scrolling when content overflows the viewport
2. **Keyboard Submit Implemented** - Created reusable `useKeyboardSubmit` hook for Cmd/Ctrl+Enter submission with visual keyboard hint on submit button
3. **Date Field Responsiveness Fixed** - Added `w-full` class to date input for proper responsive width on mobile and smaller screens

## Changes

- **src/components/ui/LogPracticeModal.tsx** - Updated to use new hook and apply responsive styling
- **src/hooks/useKeyboardSubmit.ts** - New reusable hook for keyboard submission pattern (68 lines)
- **src/hooks/useKeyboardSubmit.test.ts** - Comprehensive test suite with 12 tests for hook functionality

## Test Plan

- [ ] Modal scrolls on small screens when content overflows
- [ ] Submit button remains reachable on all screen sizes  
- [ ] Cmd+Enter (Mac) / Ctrl+Enter (Windows) submits the form
- [ ] Submit button displays keyboard shortcut hint
- [ ] Date fields stay within form boundaries on mobile (375px)
- [ ] All existing tests pass
- [ ] Manual testing on mobile viewport (DevTools)

Closes #173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form submission now supports keyboard shortcuts (Cmd+Enter on Mac, Ctrl+Enter on Windows/Linux) with visual hint displayed on submit button.
  * Improved modal dialog scrolling behavior for large content.

* **Improvements**
  * Enhanced form input styling for better usability.

* **Tests**
  * Added comprehensive test coverage for keyboard submission functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->