### PR TITLE
refactor(schedule): use Textarea primitive for notes field

### DIFF
--- a/src/components/ScheduleManager.tsx
+++ b/src/components/ScheduleManager.tsx
@@ -13,6 +13,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Textarea,
 } from '@/components/primitives';
 import { ConfirmDialog, EmptyState, toast } from '@/components/ui';
 import { StorageService } from '@/services/storageService';
@@ -266,11 +267,11 @@ export const ScheduleManager: React.FC<ScheduleManagerProps> = memo(function Sch
               </div>
               <div className="md:col-span-2 space-y-2">
                 <Label htmlFor="event-notes">Notes</Label>
-                <textarea
+                <Textarea
                   id="event-notes"
                   value={newEvent.notes || ''}
                   onChange={e => handleEventFieldChange('notes', e.target.value)}
-                  className="flex min-h-20 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-none"
+                  className="min-h-20 resize-none"
                   placeholder="Details about the session..."
                 />
               </div>


### PR DESCRIPTION
## Summary

- Replaced inline `<textarea>` element with `Textarea` component from primitives
- Improved consistency with component architecture and design system
- Maintained functional behavior with minimal style overrides

## Changes

```
 src/components/ScheduleManager.tsx | 5 +++--
 1 file changed, 3 insertions(+), 2 deletions(-)
```

Key changes:
- Added `Textarea` to primitive imports
- Changed from raw HTML `<textarea>` to `<Textarea />` component
- Updated className to `"min-h-20 resize-none"` for minimal overrides

## Test plan

- [x] Component renders correctly in form
- [x] Notes field accepts and displays user input
- [x] Placeholder text displays as expected
- [x] Styling consistent with design system
- [x] All tests pass

Closes #181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the event notes input styling and component implementation for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->