### PR TITLE
fix(team-config): use non-empty sentinel value for Select.Item

### DIFF
--- a/src/components/LinkAccountSection.tsx
+++ b/src/components/LinkAccountSection.tsx
@@ -46,13 +46,16 @@ export const LinkAccountSection = memo(function LinkAccountSection({
   const [isClaiming, setIsClaiming] = useState(false);
   const [isSavingPreference, setIsSavingPreference] = useState(false);
 
+  // Sentinel value for "None" option since Radix Select requires non-empty string values
+  const NONE_VALUE = '__none__';
+
   const handlePreferredInstrumentChange = async (value: string) => {
     if (!linkedMember) return;
 
     setIsSavingPreference(true);
     try {
-      // value of '' means "None" was selected, convert to null
-      const preferredInstrument = value === '' ? null : value;
+      // NONE_VALUE means "None" was selected, convert to null
+      const preferredInstrument = value === NONE_VALUE ? null : value;
       onUpdateMember({
         ...linkedMember,
         preferredInstrument,
@@ -166,7 +169,7 @@ export const LinkAccountSection = memo(function LinkAccountSection({
                 Preferred Instrument
               </Label>
               <Select
-                value={linkedMember.preferredInstrument || ''}
+                value={linkedMember.preferredInstrument || NONE_VALUE}
                 onValueChange={handlePreferredInstrumentChange}
                 disabled={isSavingPreference}
               >
@@ -174,7 +177,7 @@ export const LinkAccountSection = memo(function LinkAccountSection({
                   <SelectValue placeholder="Select your instrument..." />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">None</SelectItem>
+                  <SelectItem value={NONE_VALUE}>None</SelectItem>
                   {availableRoles.map(role => (
                     <SelectItem key={role} value={role}>
                       {role}


### PR DESCRIPTION
Radix UI Select requires all SelectItem values to be non-empty strings. The "None" option was using an empty string value which caused an error when navigating to the Team tab in Config.

Replaced empty string with "__none__" sentinel value and updated the handler to convert it back to null for the preferredInstrument field.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved the "None" option functionality in the Preferred Instrument selector to ensure it correctly saves and persists user selections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->