### PR TITLE
feat(my-songs): Clarify user status vs band status badges (#188)

### DIFF
--- a/src/components/MySongs.tsx
+++ b/src/components/MySongs.tsx
@@ -7,7 +7,8 @@ import {
   CardContent,
   CardHeader,
 } from '@/components/primitives';
-import { EmptyState, StatusBadge } from '@/components/ui';
+import { EmptyState } from '@/components/ui';
+import { SongStatusBadges } from '@/components/SongStatusBadges';
 import { cn } from '@/lib/utils';
 import { getPracticeRoute } from '@/routes';
 import { useLinkedMember } from '@/hooks/useLinkedMember';
@@ -29,17 +30,6 @@ interface SongWithStatus {
 }
 
 // =============================================================================
-// CONSTANTS
-// =============================================================================
-
-const USER_STATUS_LABELS: Record<string, { label: string; className: string }> = {
-  'Not Started': { label: 'Not Started', className: 'bg-muted text-muted-foreground' },
-  'Learning': { label: 'Learning', className: 'bg-info/20 text-info' },
-  'Learned': { label: 'Learned', className: 'bg-success/20 text-success' },
-  'Mastered': { label: 'Mastered', className: 'bg-primary/20 text-primary' },
-};
-
-// =============================================================================
 // SUB-COMPONENTS
 // =============================================================================
 
@@ -56,10 +46,6 @@ const SongRow = memo(function SongRow({
   onNavigateToSong,
   onPractice,
 }: SongRowProps) {
-  const statusConfig = userStatus?.status
-    ? USER_STATUS_LABELS[userStatus.status]
-    : USER_STATUS_LABELS['Not Started'];
-
   return (
     <div
       className={cn(
@@ -81,17 +67,9 @@ const SongRow = memo(function SongRow({
         </button>
       </div>
 
-      {/* Status badges */}
+      {/* Status badges - now uses SongStatusBadges for clear distinction */}
       <div className="flex items-center gap-2 shrink-0">
-        <StatusBadge status={song.status} />
-        <span
-          className={cn(
-            'px-2 py-0.5 rounded-full text-xs font-medium',
-            statusConfig.className
-          )}
-        >
-          {statusConfig.label}
-        </span>
+        <SongStatusBadges song={song} userStatus={userStatus} />
       </div>
 
       {/* Practice button */}

--- a/src/components/SongStatusBadges.tsx
+++ b/src/components/SongStatusBadges.tsx
@@ -1,5 +1,12 @@
 import React, { memo } from 'react';
-import { Badge } from '@/components/primitives';
+import { Users, User } from 'lucide-react';
+import {
+  Badge,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/primitives';
 import type { Song, UserSongProgress, UserSongStatus } from '@/types';
 
 // =============================================================================
@@ -63,14 +70,19 @@ function getUserStatusVariant(status: UserSongStatus): BadgeVariant {
 /**
  * SongStatusBadges - Display band and personal learning status badges for a song
  *
- * Shows up to two badges:
- * 1. Band status (if showBandStatus is true): "Band: Performance Ready", etc.
- * 2. Personal status (if userStatus exists): "You: Mastered", etc.
+ * Shows up to two badges with clear visual distinction:
+ * 1. Band status (if showBandStatus is true): Shows band's official song status
+ *    - Icon: Users (group icon)
+ *    - Tooltip: "Band's official status for this song"
+ * 2. Personal status (if userStatus exists): Shows user's learning progress
+ *    - Icon: User (person icon)
+ *    - Tooltip: "Your personal learning progress"
  *
  * Design System:
  * - Uses Badge primitive with semantic variants
- * - Flexbox container with gap and wrap
- * - Status-appropriate color coding
+ * - Icons provide visual distinction beyond color
+ * - Tooltips provide additional context on hover/focus
+ * - Accessible via aria-labels and screen reader support
  *
  * @example
  * ```tsx
@@ -85,21 +97,47 @@ export const SongStatusBadges = memo(function SongStatusBadges({
   className,
 }: SongStatusBadgesProps) {
   return (
-    <div className={`flex items-center gap-2 flex-wrap ${className ?? ''}`}>
-      {/* Band Status Badge */}
-      {showBandStatus && (
-        <Badge variant={getBandStatusVariant(song.status)}>
-          Band: {song.status}
-        </Badge>
-      )}
+    <TooltipProvider delayDuration={300}>
+      <div className={`flex items-center gap-2 flex-wrap ${className ?? ''}`}>
+        {/* Band Status Badge */}
+        {showBandStatus && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                variant={getBandStatusVariant(song.status)}
+                className="gap-1"
+                aria-label={`Band status: ${song.status}`}
+              >
+                <Users size={12} aria-hidden="true" />
+                <span>{song.status}</span>
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>Band&apos;s official status for this song</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
 
-      {/* Personal Status Badge - only show when user has a status */}
-      {userStatus && (
-        <Badge variant={getUserStatusVariant(userStatus.status)}>
-          You: {userStatus.status}
-        </Badge>
-      )}
-    </div>
+        {/* Personal Status Badge - only show when user has a status */}
+        {userStatus && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                variant={getUserStatusVariant(userStatus.status)}
+                className="gap-1"
+                aria-label={`Your progress: ${userStatus.status}`}
+              >
+                <User size={12} aria-hidden="true" />
+                <span>{userStatus.status}</span>
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>Your personal learning progress</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </TooltipProvider>
   );
 });
 


### PR DESCRIPTION
## Summary

Clarifies the distinction between user status badges and band status badges in the My Songs view. User status shows activity across all user songs, while band status shows activity only within the current band.

This resolves issue #188 by providing clearer visual and textual differentiation between these two status indicators.

## Changes

 src/components/MySongs.tsx          | 30 ++------------
 src/components/SongStatusBadges.tsx | 78 +++++++++++++++++++++++++++----------
 2 files changed, 62 insertions(+), 46 deletions(-)

## Test plan

- [ ] Visual verification: Status badges appear correctly
- [ ] User status badge reflects personal song activity
- [ ] Band status badge reflects current band song activity
- [ ] All tests pass
- [ ] Manual testing completed

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status badges now include visual icons for enhanced clarity: Users icon for Band status and User icon for Personal status.
  * Tooltip information appears when hovering over badges, providing context such as "Band's official status for this song" and "Your personal learning progress".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->