### PR TITLE
feat(my-songs): add 'My Status' column to narrowest view

### DIFF
--- a/src/components/MySongs.tsx
+++ b/src/components/MySongs.tsx
@@ -234,8 +234,8 @@ const VirtualizedSongTable = memo(function VirtualizedSongTable({
           <td className="w-32 py-3 px-4 hidden md:table-cell whitespace-nowrap" headers={COLUMN_IDS.bandStatus}>
             <SongStatusBadges song={song} showBandStatus userStatus={null} />
           </td>
-          {/* User Status - fixed width, hidden on mobile */}
-          <td className="w-28 py-3 px-4 hidden sm:table-cell whitespace-nowrap" headers={COLUMN_IDS.userStatus}>
+          {/* User Status - fixed width, always visible */}
+          <td className="w-28 py-3 px-4 whitespace-nowrap" headers={COLUMN_IDS.userStatus}>
             <SongStatusBadges
               song={song}
               showBandStatus={false}
@@ -352,7 +352,7 @@ const VirtualizedSongTable = memo(function VirtualizedSongTable({
         </th>
         <th
           id={COLUMN_IDS.userStatus}
-          className="w-28 text-left py-3 px-4 text-sm font-semibold text-muted-foreground hidden sm:table-cell"
+          className="w-28 text-left py-3 px-4 text-sm font-semibold text-muted-foreground"
           aria-sort={sortBy === 'userStatus' ? (sortDirection === 'asc' ? 'ascending' : 'descending') : 'none'}
         >
           <button


### PR DESCRIPTION
## Summary

Restores the 'My Status' column to the narrowest viewport layout for the My Songs page. While this column was previously hidden due to space concerns, we now show it can fit, and it's arguably the most important column for the My Songs view, allowing users to sort and filter by their personal learning status.

## Changes

src/components/MySongs.tsx | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

The change optimizes column visibility rules to display 'My Status' even in the narrowest breakpoint.

## Test plan

- [x] Verify 'My Status' column appears in narrowest viewport
- [x] Verify column is properly styled and readable
- [x] Verify sort/filter functionality works with column
- [ ] Manual testing on mobile device completed
- [ ] All tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * User Status column in the songs table is now always visible across all screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->