### PR TITLE
feat: Set default user status for songs to 'not started' badge

### DIFF
--- a/src/components/SongStatusBadges.tsx
+++ b/src/components/SongStatusBadges.tsx
@@ -36,9 +36,11 @@ export interface SongStatusBadgesProps {
  * 1. Band status (if showBandStatus is true): Shows band's official song status
  *    - Icon: Users (group icon)
  *    - Tooltip: "Band's official status for this song"
- * 2. Personal status (if userStatus exists): Shows user's learning progress
+ * 2. Personal status: Shows user's learning progress
  *    - Icon: User (person icon)
  *    - Tooltip: "Your personal learning progress"
+ *    - Defaults to "Not Started" when userStatus is undefined
+ *    - Hidden when userStatus is explicitly null (for band-only views)
  *
  * Design System:
  * - Uses Badge primitive with semantic variants
@@ -58,6 +60,13 @@ export const SongStatusBadges = memo(function SongStatusBadges({
   showBandStatus = true,
   className,
 }: SongStatusBadgesProps) {
+  // Determine whether to show user status badge and what status to display
+  // - null: explicitly hide the user badge (band-only view)
+  // - undefined: show badge with "Not Started" default
+  // - UserSongProgress: show badge with actual status
+  const showUserStatus = userStatus !== null;
+  const displayUserStatus = userStatus?.status ?? 'Not Started';
+
   return (
     <TooltipProvider delayDuration={300}>
       <div className={`flex items-center gap-2 flex-wrap ${className ?? ''}`}>
@@ -80,17 +89,17 @@ export const SongStatusBadges = memo(function SongStatusBadges({
           </Tooltip>
         )}
 
-        {/* Personal Status Badge - only show when user has a status */}
-        {userStatus && (
+        {/* Personal Status Badge - defaults to "Not Started", hidden when null */}
+        {showUserStatus && (
           <Tooltip>
             <TooltipTrigger asChild>
               <Badge
-                variant={getUserStatusVariant(userStatus.status)}
+                variant={getUserStatusVariant(displayUserStatus)}
                 className="gap-1"
-                aria-label={`Your progress: ${userStatus.status}`}
+                aria-label={`Your progress: ${displayUserStatus}`}
               >
                 <User size={12} aria-hidden="true" />
-                <span>{userStatus.status}</span>
+                <span>{displayUserStatus}</span>
               </Badge>
             </TooltipTrigger>
             <TooltipContent side="top">


### PR DESCRIPTION
## Summary

Sets the default user/personal status for songs to the 'not started' badge when songs are created or first viewed.

## Changes

```
 src/components/SongStatusBadges.tsx | 21 +++++++++++++++------
 1 file changed, 15 insertions(+), 6 deletions(-)
```

## Implementation Details

Updates the SongStatusBadges component to initialize user status to a "not started" state, providing users with a clear default status indicator for newly added songs.

## Test plan

- [ ] Verify songs display "not started" badge on creation
- [ ] Check status updates work as expected
- [ ] Visual styling is correct in both light and dark modes
- [ ] All existing tests pass
- [ ] Manual testing of status updates completed

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved personal status badge display to show "Not Started" as the default status when not explicitly defined
  * Status badge now properly hidden when user status is unavailable
  * Enhanced accessibility with updated status descriptions and labels

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->