### PR TITLE
feat(my-songs): add Learned and Not Started stat cards

### DIFF
--- a/src/components/MySongs.tsx
+++ b/src/components/MySongs.tsx
@@ -609,17 +609,16 @@ export const MySongs: React.FC<MySongsProps> = memo(function MySongs({
     let mastered = 0;
     let learned = 0;
     let learning = 0;
-    let notStarted = 0;
-    let totalPracticeTime = 0;
 
     for (const item of mySongs) {
       const status = item.userStatus?.status;
       if (status === 'Mastered') mastered++;
       else if (status === 'Learned') learned++;
       else if (status === 'Learning') learning++;
-      else notStarted++;
-      totalPracticeTime += item.totalPracticeMinutes;
     }
+
+    // Derive notStarted to guarantee the invariant: total = mastered + learned + learning + notStarted
+    const notStarted = mySongs.length - (mastered + learned + learning);
 
     return {
       total: mySongs.length,
@@ -627,7 +626,6 @@ export const MySongs: React.FC<MySongsProps> = memo(function MySongs({
       learned,
       learning,
       notStarted,
-      totalPracticeTime,
     };
   }, [mySongs]);
 
@@ -955,7 +953,7 @@ export const MySongs: React.FC<MySongsProps> = memo(function MySongs({
           title="Learned"
           value={mySongsStats.learned}
           icon={CheckCircle2}
-          variant="success"
+          variant="info"
         />
         <StatCard
           title="Learning"


### PR DESCRIPTION
## Summary

Implements the enhancement suggestions from claude-review on PR #225:

- **Track "Learned" status**: Added as intermediate milestone between "Learning" and "Mastered"
- **Add "Not Started" count**: Helps users see their backlog of songs they haven't started yet

## Changes

- Updated `mySongsStats` calculation to track `learned` and `notStarted` counts
- Expanded stat cards from 4 to 5 with responsive grid layout:
  - Mobile: 2 columns
  - Medium: 3 columns  
  - Large: 5 columns
- New stat cards use `CheckCircle2` (Learned) and `Circle` (Not Started) icons
- Removed Practice Time card to make room for more actionable status metrics

## Test plan

- [ ] Verify all 5 stat cards display correctly on mobile, tablet, and desktop
- [ ] Confirm counts are accurate for each status category
- [ ] Check that Not Started = Total - (Mastered + Learned + Learning)

Relates to: #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Learned" stat to track songs you've learned.
  * Added a "Not Started" stat to show songs you haven't begun.
  * Replaced the previous Practice Time metric with Not Started.
  * Updated the stats card layout and responsive grid for better display across screen sizes.
  * Refreshed stat card icons and labels to reflect the new metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->