### PR TITLE
feat(practice): implement Phase 4 Practice Integration with section-aware logging

### DIFF
--- a/specs/feat-phase4-practice-integration.md
+++ b/specs/feat-phase4-practice-integration.md
@@ -1,0 +1,614 @@
+# Specification: Phase 4 Practice Integration
+
+| Field       | Value                    |
+| ----------- | ------------------------ |
+| **Status**  | Active                   |
+| **Authors** | Claude & Jason           |
+| **Created** | 2025-12-21               |
+| **Updated** | 2025-12-21               |
+| **Priority**| High                     |
+| **Type**    | Feature                  |
+| **Effort**  | Small-Medium (2-3 days)  |
+| **Parent**  | feat-song-collaboration-architecture.md |
+| **Phase**   | 4 of 5                   |
+
+---
+
+## 1. Overview
+
+Phase 4 integrates song sections with the practice tracking system, enabling users to log practice sessions tied to specific sections of a song. This provides granular practice analytics, allowing users to identify which sections need more attention and track progress at a structural level rather than just song-level.
+
+## 2. Problem Statement
+
+Currently, practice sessions are logged at the song level with only free-text section names (comma-separated strings). This creates several issues:
+
+1. **No validation**: Users can type any text for "sections practiced", leading to inconsistent data (e.g., "intro", "Intro", "INTRO", "Opening" for the same section)
+2. **No linking**: Practice data cannot be correlated with actual song sections defined in Phase 1
+3. **No section-level analytics**: Users cannot see "I've practiced the Solo 47 times but only the Intro 3 times"
+4. **Missed navigation opportunities**: The Practice Room has section navigation but doesn't track which sections the user focused on
+
+## 3. Goals
+
+- Enable section-aware practice logging with validated section IDs instead of free-text
+- Provide a section picker UI in the LogPracticeModal for selecting practiced sections
+- Display section-based practice statistics (total time per section, session count per section)
+- Add keyboard shortcuts in Practice Room for quick section navigation (1-9 keys, arrow keys)
+- Show practice history filtered by section in PracticeHistory and SongDetail pages
+
+## 4. Non-Goals
+
+- Automatic practice tracking based on playback position (future enhancement)
+- Practice "streaks" or gamification features
+- Integration with metronome or tempo tracking per section
+- Multi-section loop practice mode (select sections A and B to loop)
+- Exporting practice data to external formats
+
+## 5. Requirements
+
+### 5.1 Functional Requirements
+
+| ID | Requirement | Acceptance Criteria |
+|----|-------------|---------------------|
+| FR-1 | Add `section_ids` column to `practice_sessions` table | Migration adds `section_ids UUID[]` column; existing `sections_practiced TEXT[]` column remains for backwards compatibility; column accepts null or array of valid section UUIDs |
+| FR-2 | SectionPicker component shows song sections as selectable chips | When song is selected in LogPracticeModal, available sections load from `useSongSections`; user can toggle individual sections on/off; selected sections shown with primary color highlight; empty state shows "No sections defined" message |
+| FR-3 | LogPracticeModal integrates SectionPicker | SectionPicker appears below song selector when song has sections; selected section IDs saved to `section_ids` array; backwards-compatible with `sections_practiced` text field for songs without sections; edit mode pre-selects previously logged sections |
+| FR-4 | Practice statistics include section breakdown | `usePracticeStats` hook extended to return `bySection: Map<string, { totalMinutes: number; sessionCount: number }>` keyed by section ID; aggregation query joins practice_sessions.section_ids with song_sections |
+| FR-5 | SectionStatsCard displays per-section practice time | New component renders section stats in SongDetail STRUCTURE tab; shows bar chart or pill list of sections with practice time; positioned below SectionList component |
+| FR-6 | Keyboard shortcuts navigate to sections in Practice Room | Keys 1-9 jump to sections 1-9; ArrowLeft/ArrowRight move to prev/next section when SectionNav container is focused; shortcuts only active when SectionNav container has focus via tabIndex; shortcuts disabled when input fields are focused; AlphaTab keyboard conflicts prevented by capturing events at SectionNav level before bubbling |
+| FR-7 | PracticeHistory filters by section | Add section filter dropdown in PracticeHistory filter bar; filter shows sections from all songs or current song when song filter active; sessions displayed show section badges |
+
+### 5.2 Technical Requirements
+
+- Database migration must be reversible (provide down migration)
+- `section_ids` column uses PostgreSQL array type for efficient querying with `@>` operator
+- Real-time sync not required for practice data (polling-based refresh acceptable)
+- SectionPicker must be keyboard accessible (Enter/Space to toggle, Tab to navigate)
+- Maintain backwards compatibility: existing sessions with `sections_practiced` text still display correctly
+
+## 6. Implementation Approach
+
+### 6.1 Database Migration
+
+Add `section_ids` column to `practice_sessions` table:
+
+```sql
+-- Migration: Add section_ids to practice_sessions
+ALTER TABLE practice_sessions
+ADD COLUMN section_ids UUID[] DEFAULT NULL;
+
+-- Index for efficient array queries
+CREATE INDEX idx_practice_sessions_section_ids
+ON practice_sessions USING GIN (section_ids);
+
+-- Comment for documentation
+COMMENT ON COLUMN practice_sessions.section_ids IS
+  'Array of song_sections.id UUIDs practiced in this session. Replaces free-text sections_practiced field.';
+```
+
+### 6.2 Type Updates
+
+Extend `PracticeSession` interface in `src/types.ts`:
+
+```typescript
+export interface PracticeSession {
+  id: string;
+  userId: string;
+  songId: string;
+  bandId: string;
+  durationMinutes: number;
+  tempoBpm?: number;
+  sectionsPracticed?: string[];  // Legacy: free-text section names
+  sectionIds?: string[];          // NEW: array of song_sections.id UUIDs
+  notes?: string;
+  date: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 6.3 Service Layer Updates
+
+Modify `supabaseStorageService.logPracticeSession()`:
+
+```typescript
+async logPracticeSession(
+  session: Omit<PracticeSession, 'id' | 'createdAt' | 'updatedAt'>
+): Promise<PracticeSession> {
+  // ... existing validation ...
+
+  const { data, error } = await supabase
+    .from('practice_sessions')
+    .insert({
+      user_id: session.userId,
+      song_id: session.songId,
+      band_id: session.bandId,
+      duration_minutes: session.durationMinutes,
+      tempo_bpm: session.tempoBpm ?? null,
+      sections_practiced: session.sectionsPracticed ?? null, // Legacy
+      section_ids: session.sectionIds ?? null,                // NEW
+      notes: session.notes ?? null,
+      date: session.date,
+    })
+    .select()
+    .single();
+  // ... rest of method ...
+}
+```
+
+### 6.4 SectionPicker Component
+
+Create `src/components/ui/SectionPicker.tsx`:
+
+```typescript
+export interface SectionPickerProps {
+  /** Song ID to load sections for */
+  songId: string | null;
+  /** Band ID for section loading */
+  bandId: string | null;
+  /** Currently selected section IDs */
+  selectedSectionIds: string[];
+  /** Called when selection changes */
+  onSelectionChange: (sectionIds: string[]) => void;
+  /** Optional className */
+  className?: string;
+}
+
+export const SectionPicker: React.FC<SectionPickerProps> = memo(function SectionPicker({
+  songId,
+  bandId,
+  selectedSectionIds,
+  onSelectionChange,
+  className,
+}) {
+  const { sections, isLoading } = useSongSections(songId, bandId);
+
+  const toggleSection = useCallback((sectionId: string) => {
+    if (selectedSectionIds.includes(sectionId)) {
+      onSelectionChange(selectedSectionIds.filter(id => id !== sectionId));
+    } else {
+      onSelectionChange([...selectedSectionIds, sectionId]);
+    }
+  }, [selectedSectionIds, onSelectionChange]);
+
+  // Render: loading spinner, empty state, or section chips
+});
+```
+
+**Props Interface:**
+- `songId`: Required to fetch sections via `useSongSections` hook
+- `bandId`: Required for band context in section queries
+- `selectedSectionIds`: Controlled array of selected UUIDs
+- `onSelectionChange`: Callback receives updated selection array
+
+**Integration with useSongSections:**
+- Uses existing `src/hooks/useSongSections.ts` hook
+- Returns `{ sections, isLoading, error }` for the specified song
+- Sections sorted by `displayOrder` for consistent chip ordering
+
+**State Flow:**
+1. Parent (LogPracticeModal) owns `selectedSectionIds` state
+2. SectionPicker renders chips from `useSongSections` data
+3. Chip click calls `toggleSection` which updates parent state via `onSelectionChange`
+4. Parent includes `selectedSectionIds` in form submission
+
+### 6.5 LogPracticeModal Integration
+
+Modify `src/components/ui/LogPracticeModal.tsx`:
+
+**State Changes:**
+```typescript
+interface FormState {
+  // ... existing fields ...
+  sectionIds: string[];  // NEW: array of selected section UUIDs
+}
+```
+
+**Initialization Logic:**
+```typescript
+function computeInitialFormState(
+  editSession: PracticeSession | undefined,
+  // ...
+): FormState {
+  if (editSession) {
+    return {
+      // ... existing fields ...
+      sectionIds: editSession.sectionIds ?? [],  // Pre-populate from session
+    };
+  }
+  return {
+    // ... existing fields ...
+    sectionIds: [],  // Empty for new sessions
+  };
+}
+```
+
+**Render Integration:**
+Insert SectionPicker after song selector, conditionally rendered when song is selected:
+```tsx
+{/* Song selection */}
+<div className="space-y-2">
+  <Label htmlFor="song-select">Song *</Label>
+  <Select value={songId} onValueChange={handleSongChange}>
+    {/* ... */}
+  </Select>
+</div>
+
+{/* Section picker - NEW */}
+{songId && (
+  <div className="space-y-2">
+    <Label>Sections Practiced</Label>
+    <SectionPicker
+      songId={songId}
+      bandId={currentBandId}
+      selectedSectionIds={formState.sectionIds}
+      onSelectionChange={(ids) => setFormState(prev => ({ ...prev, sectionIds: ids }))}
+    />
+  </div>
+)}
+```
+
+**Submission Changes:**
+Include `sectionIds` in the `PracticeFormData` passed to `onSubmit`:
+```typescript
+await onSubmit({
+  songId,
+  durationMinutes: duration,
+  tempoBpm: tempo,
+  sectionIds: formState.sectionIds.length > 0 ? formState.sectionIds : undefined,  // NEW
+  sectionsPracticed: sectionsPracticed.length > 0 ? sectionsPracticed : undefined, // Legacy
+  notes: notes.trim() || undefined,
+  date,
+});
+```
+
+### 6.6 SectionStatsCard Component
+
+Create `src/components/structure/SectionStatsCard.tsx`:
+
+```typescript
+export interface SectionStats {
+  sectionId: string;
+  sectionName: string;
+  totalMinutes: number;
+  sessionCount: number;
+}
+
+export interface SectionStatsCardProps {
+  /** Song ID to show stats for */
+  songId: string;
+  /** Band ID for queries */
+  bandId: string;
+  /** User ID for filtering */
+  userId: string;
+  /** Sections with names for display */
+  sections: SongSection[];
+  /** Optional className */
+  className?: string;
+}
+
+export const SectionStatsCard: React.FC<SectionStatsCardProps> = memo(function SectionStatsCard({
+  songId,
+  bandId,
+  userId,
+  sections,
+  className,
+}) {
+  // Fetch section-level practice stats via extended usePracticeStats hook
+  const { sectionStats, isLoading } = usePracticeStats(userId, bandId, { songId });
+
+  // Map section IDs to names for display
+  const statsWithNames = useMemo(() => {
+    return sections.map(section => ({
+      sectionId: section.id,
+      sectionName: section.name,
+      totalMinutes: sectionStats.get(section.id)?.totalMinutes ?? 0,
+      sessionCount: sectionStats.get(section.id)?.sessionCount ?? 0,
+    }));
+  }, [sections, sectionStats]);
+
+  // Render: horizontal bar chart or pill list showing practice time per section
+});
+```
+
+**Integration Points:**
+- Placed in SongDetail STRUCTURE tab below SectionList
+- Uses extended `usePracticeStats` hook with new `sectionStats` return value
+- Receives `sections` prop from parent's `useSongSections` call
+
+### 6.7 usePracticeStats Hook Extension
+
+Modify `src/hooks/usePracticeStats.ts`:
+
+```typescript
+export interface PracticeStats {
+  totalSessions: number;
+  totalMinutes: number;
+  averageSessionMinutes: number;
+  songsLearned: number;
+  songsMastered: number;
+  recentSessions: PracticeSession[];
+  sectionStats: Map<string, { totalMinutes: number; sessionCount: number }>;  // NEW
+}
+
+// Query for section stats:
+const sectionQuery = await supabase
+  .from('practice_sessions')
+  .select('duration_minutes, section_ids')
+  .eq('user_id', userId)
+  .eq('band_id', bandId)
+  .not('section_ids', 'is', null);
+
+// Aggregate results into Map
+const sectionStats = new Map<string, { totalMinutes: number; sessionCount: number }>();
+for (const session of sectionQuery.data ?? []) {
+  const sectionIds = session.section_ids as string[] | null;
+  if (!sectionIds) continue;
+
+  const perSectionMinutes = session.duration_minutes / sectionIds.length;
+  for (const sectionId of sectionIds) {
+    const existing = sectionStats.get(sectionId) ?? { totalMinutes: 0, sessionCount: 0 };
+    sectionStats.set(sectionId, {
+      totalMinutes: existing.totalMinutes + perSectionMinutes,
+      sessionCount: existing.sessionCount + 1,
+    });
+  }
+}
+```
+
+### 6.8 Keyboard Navigation in Practice Room
+
+Modify `src/components/practice/SectionNav.tsx`:
+
+```typescript
+export interface SectionNavProps {
+  sections: SongSection[];
+  currentBar?: number;
+  totalBars: number;
+  onSectionClick: (section: SongSection) => void;
+  className?: string;
+}
+
+export const SectionNav: React.FC<SectionNavProps> = memo(function SectionNav({
+  sections,
+  currentBar,
+  totalBars,
+  onSectionClick,
+  className,
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Find current section index for arrow key navigation
+  const currentSectionIndex = useMemo(() => {
+    if (!currentBar) return -1;
+    return sections.findIndex(s => currentBar >= s.startBar && currentBar <= s.endBar);
+  }, [currentBar, sections]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Check if an input field has focus - if so, ignore shortcuts
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLInputElement ||
+        activeElement instanceof HTMLTextAreaElement ||
+        activeElement instanceof HTMLSelectElement) {
+      return;
+    }
+
+    // Number keys 1-9 jump to sections
+    if (e.key >= '1' && e.key <= '9') {
+      const index = parseInt(e.key, 10) - 1;
+      if (index < sections.length) {
+        e.preventDefault();
+        e.stopPropagation();  // Prevent AlphaTab from capturing
+        onSectionClick(sections[index]);
+      }
+    }
+
+    // Arrow keys navigate relative to current section
+    if (e.key === 'ArrowLeft' && currentSectionIndex > 0) {
+      e.preventDefault();
+      e.stopPropagation();
+      onSectionClick(sections[currentSectionIndex - 1]);
+    }
+    if (e.key === 'ArrowRight' && currentSectionIndex < sections.length - 1) {
+      e.preventDefault();
+      e.stopPropagation();
+      onSectionClick(sections[currentSectionIndex + 1]);
+    }
+  }, [sections, currentSectionIndex, onSectionClick]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn('border-b border-border bg-card/50', className)}
+      tabIndex={0}  // Make focusable for keyboard events
+      onKeyDown={handleKeyDown}
+      role="navigation"
+      aria-label="Section navigation. Press 1-9 to jump to sections, arrow keys to navigate."
+    >
+      {/* ... existing content ... */}
+    </div>
+  );
+});
+```
+
+**Focus Handling:**
+- Container has `tabIndex={0}` to receive keyboard focus
+- Keyboard shortcuts only fire when SectionNav container has focus
+- User clicks inside Practice Room to focus SectionNav, then uses keyboard
+- Input fields (tempo, BPM) are excluded via `activeElement` check
+
+**AlphaTab Conflict Prevention:**
+- `e.stopPropagation()` prevents events from bubbling to AlphaTab
+- AlphaTab only captures events that reach its container
+- SectionNav positioned above AlphaTab in DOM, receives events first
+
+### 6.9 PracticeHistory Section Filter
+
+Modify `src/components/PracticeHistory.tsx`:
+
+**Filter State:**
+```typescript
+interface FilterState {
+  // ... existing filters ...
+  sectionId: string | null;  // NEW: filter by section
+}
+```
+
+**Filter UI:**
+```tsx
+{/* Section filter - only shown when song filter is active */}
+{filters.songId && (
+  <div className="space-y-1">
+    <Label htmlFor="section-filter" className="text-xs">Section</Label>
+    <Select
+      value={filters.sectionId ?? 'all'}
+      onValueChange={(v) => setFilters(prev => ({
+        ...prev,
+        sectionId: v === 'all' ? null : v
+      }))}
+    >
+      <SelectTrigger id="section-filter" className="h-9">
+        <SelectValue placeholder="All sections" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">All sections</SelectItem>
+        {songSections.map(section => (
+          <SelectItem key={section.id} value={section.id}>
+            {section.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  </div>
+)}
+```
+
+**Session Filtering:**
+```typescript
+// Filter sessions by section (client-side, since section_ids is an array)
+const filteredSessions = useMemo(() => {
+  if (!filters.sectionId) return sessions;
+  return sessions.filter(session =>
+    session.sectionIds?.includes(filters.sectionId!)
+  );
+}, [sessions, filters.sectionId]);
+```
+
+## 7. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Song has no sections defined | SectionPicker shows "No sections defined for this song" message; legacy `sections_practiced` text field remains functional as fallback |
+| User edits session with deleted sections | Section IDs that no longer exist in song_sections are silently filtered out on edit; save only includes valid section IDs |
+| Section deleted after practice logged | Practice history shows "Unknown section" badge with muted styling; section stats exclude deleted sections |
+| Practice session logged for multiple sections | Duration distributed equally across sections for stats (e.g., 30 min session with 3 sections = 10 min per section) |
+| Network error loading sections | SectionPicker shows error state with retry button; form still submittable without section selection |
+| User focuses AlphaTab while in Practice Room | Keyboard shortcuts in SectionNav only work when SectionNav container has focus; AlphaTab retains its own keyboard handling (space for play/pause) |
+| Keyboard shortcut pressed with input focused | Shortcuts are ignored when HTMLInputElement, HTMLTextAreaElement, or HTMLSelectElement has focus |
+| Section key 1-9 pressed but section doesn't exist | Key press ignored; no error or feedback needed |
+| Very long section list (10+ sections) | Only keys 1-9 work for direct jump; arrow keys navigate through all sections; consider future enhancement for section search |
+
+## 8. Testing Strategy
+
+### 8.1 Unit Tests
+
+**SectionPicker Component** (`src/components/ui/__tests__/SectionPicker.test.tsx`):
+
+| Test Case | Description |
+|-----------|-------------|
+| `renders loading state` | Shows spinner while sections load |
+| `renders empty state when song has no sections` | Displays "No sections defined" message |
+| `renders section chips for available sections` | Each section from useSongSections displayed as chip |
+| `toggles section selection on click` | Click unselected chip adds to selection; click selected chip removes |
+| `calls onSelectionChange with updated array` | Verify callback receives correct array after toggle |
+| `pre-selects sections from selectedSectionIds prop` | Initial selection highlighted correctly |
+| `keyboard navigation works` | Tab moves between chips; Enter/Space toggles selection |
+| `handles null songId gracefully` | Shows empty state, no error thrown |
+
+**SectionNav Keyboard Shortcuts** (`src/components/practice/SectionNav.test.tsx`):
+
+| Test Case | Description |
+|-----------|-------------|
+| `key 1 navigates to first section` | Press "1" calls onSectionClick with sections[0] |
+| `key 5 navigates to fifth section` | Press "5" calls onSectionClick with sections[4] |
+| `key 9 ignored if fewer than 9 sections` | Press "9" with 3 sections does not call onSectionClick |
+| `ArrowRight moves to next section` | From section 2, ArrowRight navigates to section 3 |
+| `ArrowLeft moves to previous section` | From section 3, ArrowLeft navigates to section 2 |
+| `ArrowLeft at first section does nothing` | From section 1, ArrowLeft does not call onSectionClick |
+| `ArrowRight at last section does nothing` | From last section, ArrowRight does not call onSectionClick |
+| `shortcuts ignored when input focused` | Focus input, press "1", verify onSectionClick not called |
+| `stopPropagation prevents AlphaTab capture` | Verify event.stopPropagation called on handled keys |
+
+**usePracticeStats Section Aggregation** (`src/hooks/__tests__/usePracticeStats.test.ts`):
+
+| Test Case | Description |
+|-----------|-------------|
+| `returns empty sectionStats when no sessions` | sectionStats Map is empty |
+| `aggregates single section correctly` | Session with one section_id adds full duration |
+| `distributes duration across multiple sections` | 60 min with 3 sections = 20 min each |
+| `counts sessions per section` | Each session increments sessionCount for its sections |
+| `excludes sessions with null section_ids` | Legacy sessions don't affect sectionStats |
+| `filters by songId when provided` | Only sessions for specified song included |
+
+### 8.2 Integration Tests
+
+**LogPracticeModal with SectionPicker** (`src/components/ui/__tests__/LogPracticeModal.integration.test.tsx`):
+
+| Test Case | Description |
+|-----------|-------------|
+| `section_ids saved to practice session` | Submit form with sections selected; verify logPracticeSession called with correct sectionIds array |
+| `edit mode pre-populates sections` | Open modal with editSession containing sectionIds; verify chips pre-selected |
+| `song change clears section selection` | Select song A with sections, change to song B, verify selection cleared |
+| `form submits without sections for songs without sections` | Song with no sections; verify form submits successfully with undefined sectionIds |
+
+**Practice Room Keyboard Navigation** (`src/components/__tests__/PracticeRoom.keyboard.test.tsx`):
+
+| Test Case | Description |
+|-----------|-------------|
+| `clicking SectionNav then pressing 1 seeks to first section` | Focus SectionNav, press "1", verify AlphaTab seekTo called |
+| `arrow keys navigate through sections` | Focus SectionNav, press ArrowRight repeatedly, verify sequential section navigation |
+| `shortcuts work after section button click` | Click section button (focuses container), press "2", verify navigation |
+
+### 8.3 Manual Validation Checklist
+
+- [ ] Log practice session with 2+ sections selected, verify saved correctly
+- [ ] Edit practice session, add/remove sections, verify persisted
+- [ ] View PracticeHistory with section filter, verify filtering works
+- [ ] View SongDetail STRUCTURE tab, verify section stats display
+- [ ] In Practice Room, click section nav area, press 1-9 keys, verify navigation
+- [ ] In Practice Room, use arrow keys to navigate sections
+- [ ] Verify keyboard shortcuts don't fire when tempo input is focused
+- [ ] Verify AlphaTab play/pause (space) still works when AlphaTab is focused
+- [ ] Test with song that has no sections defined, verify graceful fallback
+- [ ] Test legacy session (sections_practiced text), verify still displays correctly
+
+## 9. Files to Modify/Create
+
+| File | Action | Description |
+|------|--------|-------------|
+| `supabase/migrations/XXX_add_section_ids_to_practice_sessions.sql` | Create | Add `section_ids UUID[]` column, GIN index, and down migration |
+| `src/types.ts` | Modify | Add `sectionIds?: string[]` to `PracticeSession` interface |
+| `src/types/database.types.ts` | Modify | Regenerate types to include `section_ids` column |
+| `src/services/supabaseStorageService.ts` | Modify | Update `logPracticeSession`, `updatePracticeSession`, and `getPracticeSessions` to handle `section_ids` |
+| `src/components/ui/SectionPicker.tsx` | Create | Chip-based section selection component with keyboard accessibility |
+| `src/components/ui/__tests__/SectionPicker.test.tsx` | Create | Unit tests for SectionPicker component |
+| `src/components/ui/LogPracticeModal.tsx` | Modify | Integrate SectionPicker, add sectionIds to form state and submission |
+| `src/components/ui/index.ts` | Modify | Export SectionPicker component |
+| `src/components/structure/SectionStatsCard.tsx` | Create | Display per-section practice statistics |
+| `src/components/structure/index.ts` | Modify | Export SectionStatsCard component |
+| `src/hooks/usePracticeStats.ts` | Modify | Add `sectionStats` Map to return value, implement section aggregation query |
+| `src/components/practice/SectionNav.tsx` | Modify | Add keyboard event handler for 1-9 and arrow key shortcuts, tabIndex for focus |
+| `src/components/practice/SectionNav.test.tsx` | Create | Unit tests for keyboard navigation |
+| `src/components/PracticeHistory.tsx` | Modify | Add section filter dropdown, display section badges on sessions |
+
+## 10. Open Questions
+
+None - all requirements are clear.
+
+---
+
+## Related Documents
+
+- Architecture: `specs/backlog/feat-song-collaboration-architecture.md`
+- Phase 1 Spec: `specs/feat-phase1-song-sections.md`
+- Phase 2 Spec: `specs/feat-phase2-section-assignments.md`
+- Phase 3 Spec: `specs/feat-phase-3-song-annotations.md`

--- a/src/components/practice/SectionNav.tsx
+++ b/src/components/practice/SectionNav.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useMemo, useCallback, useRef } from 'react';
 import type { SongSection } from '@/types';
 import { Button } from '@/components/primitives/button';
 import { ScrollableContainer } from '@/components/ui';
@@ -22,6 +22,11 @@ export interface SectionNavProps {
 /**
  * Section navigation pills for the Practice Room.
  * Shows section buttons above the chart area with current section highlighted.
+ *
+ * Keyboard shortcuts (when focused):
+ * - 1-9: Jump directly to section 1-9
+ * - ArrowLeft: Navigate to previous section
+ * - ArrowRight: Navigate to next section
  */
 export const SectionNav: React.FC<SectionNavProps> = memo(function SectionNav({
   sections,
@@ -30,6 +35,8 @@ export const SectionNav: React.FC<SectionNavProps> = memo(function SectionNav({
   onSectionClick,
   className,
 }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
   // Determine current section based on bar position
   const currentSectionId = useMemo(() => {
     if (!currentBar || sections.length === 0) return null;
@@ -41,19 +48,76 @@ export const SectionNav: React.FC<SectionNavProps> = memo(function SectionNav({
     return current?.id ?? null;
   }, [currentBar, sections]);
 
+  // Find current section index for arrow key navigation
+  const currentSectionIndex = useMemo(() => {
+    if (!currentSectionId || sections.length === 0) return -1;
+    return sections.findIndex(s => s.id === currentSectionId);
+  }, [currentSectionId, sections]);
+
+  // Keyboard event handler for section navigation shortcuts
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      // Check if an input field has focus - if so, ignore shortcuts
+      const activeElement = document.activeElement;
+      if (
+        activeElement instanceof HTMLInputElement ||
+        activeElement instanceof HTMLTextAreaElement ||
+        activeElement instanceof HTMLSelectElement
+      ) {
+        return;
+      }
+
+      // Number keys 1-9 jump to sections
+      if (e.key >= '1' && e.key <= '9') {
+        const index = parseInt(e.key, 10) - 1;
+        if (index < sections.length) {
+          e.preventDefault();
+          e.stopPropagation(); // Prevent AlphaTab from capturing
+          onSectionClick(sections[index]);
+        }
+        return;
+      }
+
+      // Arrow keys navigate relative to current section
+      if (e.key === 'ArrowLeft' && currentSectionIndex > 0) {
+        e.preventDefault();
+        e.stopPropagation();
+        onSectionClick(sections[currentSectionIndex - 1]);
+        return;
+      }
+
+      if (e.key === 'ArrowRight' && currentSectionIndex < sections.length - 1) {
+        e.preventDefault();
+        e.stopPropagation();
+        onSectionClick(sections[currentSectionIndex + 1]);
+        return;
+      }
+    },
+    [sections, currentSectionIndex, onSectionClick]
+  );
+
   if (sections.length === 0) {
     return null;
   }
 
   return (
-    <div className={cn('border-b border-border bg-card/50', className)}>
+    <div
+      ref={containerRef}
+      className={cn('border-b border-border bg-card/50', className)}
+      tabIndex={0} // Make focusable for keyboard events
+      onKeyDown={handleKeyDown}
+      role="navigation"
+      aria-label="Section navigation. Press 1-9 to jump to sections, arrow keys to navigate."
+    >
       <ScrollableContainer fadeClassName="from-card/50">
         <div className="flex items-center gap-1.5 px-3 py-2">
           <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide mr-2 shrink-0">
             Sections
           </span>
-          {sections.map(section => {
+          {sections.map((section, index) => {
             const isCurrent = section.id === currentSectionId;
+            // Show number key hint for sections 1-9
+            const keyHint = index < 9 ? ` [${index + 1}]` : '';
 
             return (
               <Button
@@ -67,7 +131,7 @@ export const SectionNav: React.FC<SectionNavProps> = memo(function SectionNav({
                     ? 'bg-primary text-primary-foreground shadow-sm'
                     : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                 )}
-                title={`${section.name} (bars ${section.startBar}-${section.endBar})`}
+                title={`${section.name} (bars ${section.startBar}-${section.endBar})${keyHint}`}
               >
                 {section.name}
               </Button>

--- a/src/components/practice/SectionNav.tsx
+++ b/src/components/practice/SectionNav.tsx
@@ -103,7 +103,11 @@ export const SectionNav: React.FC<SectionNavProps> = memo(function SectionNav({
   return (
     <div
       ref={containerRef}
-      className={cn('border-b border-border bg-card/50', className)}
+      className={cn(
+        'border-b border-border bg-card/50',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset',
+        className
+      )}
       tabIndex={0} // Make focusable for keyboard events
       onKeyDown={handleKeyDown}
       role="navigation"

--- a/src/components/structure/SectionStatsCard.tsx
+++ b/src/components/structure/SectionStatsCard.tsx
@@ -1,0 +1,174 @@
+import React, { memo, useMemo } from 'react';
+import { Clock, Hash } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/primitives/card';
+import { cn } from '@/lib/utils';
+import type { SongSection } from '@/types';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/** Stats for a single section */
+export interface SectionStat {
+  sectionId: string;
+  sectionName: string;
+  totalMinutes: number;
+  sessionCount: number;
+}
+
+export interface SectionStatsCardProps {
+  /** Sections with names for display */
+  sections: SongSection[];
+  /** Map of sectionId to stats from usePracticeStats */
+  sectionStats: Map<string, { totalMinutes: number; sessionCount: number }>;
+  /** Loading state */
+  isLoading?: boolean;
+  /** Optional className */
+  className?: string;
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Format minutes to a human-readable string
+ * @example formatMinutes(90) // "1h 30m"
+ * @example formatMinutes(45) // "45m"
+ */
+function formatMinutes(minutes: number): string {
+  if (minutes < 60) {
+    return `${Math.round(minutes)}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const mins = Math.round(minutes % 60);
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+/**
+ * Displays per-section practice statistics.
+ * Shows a horizontal bar chart or pill list of sections with practice time.
+ * Positioned in SongDetail STRUCTURE tab below SectionList.
+ */
+export const SectionStatsCard: React.FC<SectionStatsCardProps> = memo(function SectionStatsCard({
+  sections,
+  sectionStats,
+  isLoading,
+  className,
+}) {
+  // Map section IDs to names and stats for display
+  const statsWithNames = useMemo((): SectionStat[] => {
+    return sections.map(section => ({
+      sectionId: section.id,
+      sectionName: section.name,
+      totalMinutes: sectionStats.get(section.id)?.totalMinutes ?? 0,
+      sessionCount: sectionStats.get(section.id)?.sessionCount ?? 0,
+    }));
+  }, [sections, sectionStats]);
+
+  // Calculate max minutes for relative bar sizing
+  const maxMinutes = useMemo(() => {
+    const max = Math.max(...statsWithNames.map(s => s.totalMinutes), 0);
+    return max > 0 ? max : 1; // Avoid division by zero
+  }, [statsWithNames]);
+
+  // Check if there's any practice data
+  const hasPracticeData = statsWithNames.some(s => s.sessionCount > 0);
+
+  // Show loading skeleton
+  if (isLoading) {
+    return (
+      <Card className={className}>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-serif">Practice by Section</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {[1, 2, 3].map(i => (
+              <div key={i} className="animate-pulse">
+                <div className="flex justify-between mb-1">
+                  <div className="h-4 w-20 bg-muted rounded" />
+                  <div className="h-4 w-12 bg-muted rounded" />
+                </div>
+                <div className="h-2 bg-muted rounded" />
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // No sections defined
+  if (sections.length === 0) {
+    return null;
+  }
+
+  // No practice data yet
+  if (!hasPracticeData) {
+    return (
+      <Card className={className}>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-serif">Practice by Section</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No practice sessions logged for sections yet. Start practicing to see your progress here!
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-serif">Practice by Section</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {statsWithNames.map(stat => {
+            const barWidth = stat.totalMinutes > 0
+              ? Math.max((stat.totalMinutes / maxMinutes) * 100, 5) // Minimum 5% for visibility
+              : 0;
+
+            return (
+              <div key={stat.sectionId}>
+                <div className="flex justify-between items-center mb-1">
+                  <span className="text-sm font-medium text-foreground truncate">
+                    {stat.sectionName}
+                  </span>
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
+                    <span className="flex items-center gap-1">
+                      <Hash className="h-3 w-3" />
+                      {stat.sessionCount}
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {formatMinutes(stat.totalMinutes)}
+                    </span>
+                  </div>
+                </div>
+                <div className="h-2 bg-muted rounded-full overflow-hidden">
+                  <div
+                    className={cn(
+                      'h-full bg-primary rounded-full transition-all duration-300',
+                      stat.totalMinutes === 0 && 'bg-muted-foreground/20'
+                    )}
+                    style={{ width: `${barWidth}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+});
+
+SectionStatsCard.displayName = 'SectionStatsCard';

--- a/src/components/structure/index.ts
+++ b/src/components/structure/index.ts
@@ -2,6 +2,7 @@
  * Structure components for song section management
  * Phase 1: Song Sections
  * Phase 2: Section Assignments
+ * Phase 4: Practice Integration
  */
 
 export { StructureTab } from './StructureTab';
@@ -12,3 +13,4 @@ export { ActivityIndicator } from './ActivityIndicator';
 export { AssignmentList } from './AssignmentList';
 export { AssignmentForm } from './AssignmentForm';
 export { YourAssignment } from './YourAssignment';
+export { SectionStatsCard, type SectionStat, type SectionStatsCardProps } from './SectionStatsCard';

--- a/src/components/ui/SectionPicker.tsx
+++ b/src/components/ui/SectionPicker.tsx
@@ -1,0 +1,134 @@
+import React, { memo, useCallback } from 'react';
+import { Loader2, Music2 } from 'lucide-react';
+import { useSongSections } from '@/hooks/useSongSections';
+import { cn } from '@/lib/utils';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export interface SectionPickerProps {
+  /** Song ID to load sections for */
+  songId: string | null;
+  /** Band ID for section loading */
+  bandId: string | null;
+  /** Currently selected section IDs */
+  selectedSectionIds: string[];
+  /** Called when selection changes */
+  onSelectionChange: (sectionIds: string[]) => void;
+  /** Optional className */
+  className?: string;
+}
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+/**
+ * Chip-based section selection component for selecting which sections
+ * were practiced in a practice session.
+ *
+ * - Loads sections for the specified song using useSongSections hook
+ * - Displays sections as toggleable chips sorted by displayOrder
+ * - Supports keyboard navigation (Tab to move, Enter/Space to toggle)
+ * - Shows loading, empty, and error states appropriately
+ */
+export const SectionPicker: React.FC<SectionPickerProps> = memo(function SectionPicker({
+  songId,
+  bandId,
+  selectedSectionIds,
+  onSelectionChange,
+  className,
+}) {
+  const { sections, isLoading, error } = useSongSections(songId, bandId);
+
+  const toggleSection = useCallback(
+    (sectionId: string) => {
+      if (selectedSectionIds.includes(sectionId)) {
+        onSelectionChange(selectedSectionIds.filter(id => id !== sectionId));
+      } else {
+        onSelectionChange([...selectedSectionIds, sectionId]);
+      }
+    },
+    [selectedSectionIds, onSelectionChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, sectionId: string) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        toggleSection(sectionId);
+      }
+    },
+    [toggleSection]
+  );
+
+  // No song selected
+  if (!songId) {
+    return null;
+  }
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className={cn('flex items-center gap-2 text-muted-foreground', className)}>
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span className="text-sm">Loading sections...</span>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className={cn('text-sm text-destructive', className)}>
+        Failed to load sections
+      </div>
+    );
+  }
+
+  // Empty state - no sections defined
+  if (sections.length === 0) {
+    return (
+      <div className={cn('flex items-center gap-2 text-muted-foreground', className)}>
+        <Music2 className="h-4 w-4" />
+        <span className="text-sm">No sections defined for this song</span>
+      </div>
+    );
+  }
+
+  // Render section chips
+  return (
+    <div
+      className={cn('flex flex-wrap gap-2', className)}
+      role="group"
+      aria-label="Select sections practiced"
+    >
+      {sections.map(section => {
+        const isSelected = selectedSectionIds.includes(section.id);
+        return (
+          <button
+            key={section.id}
+            type="button"
+            role="checkbox"
+            aria-checked={isSelected}
+            tabIndex={0}
+            onClick={() => toggleSection(section.id)}
+            onKeyDown={e => handleKeyDown(e, section.id)}
+            className={cn(
+              'inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium transition-all',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+              isSelected
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'
+            )}
+          >
+            {section.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+});
+
+SectionPicker.displayName = 'SectionPicker';

--- a/src/components/ui/__tests__/LogPracticeModal.test.tsx
+++ b/src/components/ui/__tests__/LogPracticeModal.test.tsx
@@ -9,6 +9,21 @@ vi.mock('@/lib/dateUtils', () => ({
   getTodayDateString: () => '2025-12-08',
 }));
 
+// Mock useSongSections hook for SectionPicker
+vi.mock('@/hooks/useSongSections', () => ({
+  useSongSections: () => ({
+    sections: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+    createSection: vi.fn(),
+    updateSection: vi.fn(),
+    deleteSection: vi.fn(),
+    upsertSections: vi.fn(),
+    deleteAllSections: vi.fn(),
+  }),
+}));
+
 const mockSongs: Song[] = [
   {
     id: 'song-1',
@@ -60,6 +75,7 @@ describe('LogPracticeModal', () => {
     isOpen: true,
     onClose: vi.fn(),
     songs: mockSongs,
+    currentBandId: 'band-1',
     onSubmit: vi.fn(),
   };
 
@@ -95,7 +111,7 @@ describe('LogPracticeModal', () => {
       expect(screen.getByLabelText(/date/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/duration/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/tempo/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/sections/i)).toBeInTheDocument();
+      // Note: Sections are now rendered via SectionPicker after song selection
       expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
     });
 
@@ -125,7 +141,8 @@ describe('LogPracticeModal', () => {
       expect(screen.getByLabelText(/date/i)).toHaveValue('2025-12-05');
       expect(screen.getByLabelText(/duration/i)).toHaveValue(45);
       expect(screen.getByLabelText(/tempo/i)).toHaveValue(120);
-      expect(screen.getByLabelText(/sections/i)).toHaveValue('Intro, Verse 1');
+      // Note: Section pre-population is now via SectionPicker (not text input)
+      // The legacy sectionsPracticed is not shown in the UI
       expect(screen.getByLabelText(/notes/i)).toHaveValue('Great progress today');
     });
 
@@ -215,8 +232,9 @@ describe('LogPracticeModal', () => {
       const tempoInput = screen.getByLabelText(/tempo/i);
       await user.type(tempoInput, '120');
 
-      const sectionsInput = screen.getByLabelText(/sections/i);
-      await user.type(sectionsInput, 'Intro, Chorus');
+      // Note: Sections are now selected via SectionPicker component
+      // When no sections exist (empty mock), the picker shows "No sections defined"
+      // We skip testing section selection here - see integration tests for SectionPicker
 
       const notesInput = screen.getByLabelText(/notes/i);
       await user.type(notesInput, 'Good session');
@@ -230,7 +248,8 @@ describe('LogPracticeModal', () => {
           songId: 'song-1',
           durationMinutes: 30, // default value
           tempoBpm: 120,
-          sectionsPracticed: ['Intro', 'Chorus'],
+          sectionsPracticed: undefined, // No legacy sections entered
+          sectionIds: undefined, // No sections selected via picker
           notes: 'Good session',
           date: '2025-12-08', // mocked today
         });

--- a/src/components/ui/__tests__/SectionPicker.test.tsx
+++ b/src/components/ui/__tests__/SectionPicker.test.tsx
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SectionPicker } from '../SectionPicker';
+import type { SongSection } from '@/types';
+
+// Mock sections for testing
+const mockSections: SongSection[] = [
+  {
+    id: 'section-1',
+    songId: 'song-1',
+    bandId: 'band-1',
+    name: 'Intro',
+    startBar: 1,
+    endBar: 8,
+    barCount: 8,
+    displayOrder: 1,
+    source: 'manual',
+    createdAt: '2025-12-01T00:00:00Z',
+    updatedAt: '2025-12-01T00:00:00Z',
+  },
+  {
+    id: 'section-2',
+    songId: 'song-1',
+    bandId: 'band-1',
+    name: 'Verse 1',
+    startBar: 9,
+    endBar: 24,
+    barCount: 16,
+    displayOrder: 2,
+    source: 'manual',
+    createdAt: '2025-12-01T00:00:00Z',
+    updatedAt: '2025-12-01T00:00:00Z',
+  },
+  {
+    id: 'section-3',
+    songId: 'song-1',
+    bandId: 'band-1',
+    name: 'Chorus',
+    startBar: 25,
+    endBar: 40,
+    barCount: 16,
+    displayOrder: 3,
+    source: 'manual',
+    createdAt: '2025-12-01T00:00:00Z',
+    updatedAt: '2025-12-01T00:00:00Z',
+  },
+];
+
+// Mock the useSongSections hook
+vi.mock('@/hooks/useSongSections', () => ({
+  useSongSections: vi.fn(),
+}));
+
+import { useSongSections } from '@/hooks/useSongSections';
+const mockUseSongSections = vi.mocked(useSongSections);
+
+describe('SectionPicker', () => {
+  const defaultProps = {
+    songId: 'song-1',
+    bandId: 'band-1',
+    selectedSectionIds: [],
+    onSelectionChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default mock returns sections
+    mockUseSongSections.mockReturnValue({
+      sections: mockSections,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+      createSection: vi.fn(),
+      updateSection: vi.fn(),
+      deleteSection: vi.fn(),
+      upsertSections: vi.fn(),
+      deleteAllSections: vi.fn(),
+    });
+  });
+
+  describe('rendering', () => {
+    it('should render nothing when songId is null', () => {
+      const { container } = render(
+        <SectionPicker {...defaultProps} songId={null} />
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('should show loading state when loading sections', () => {
+      mockUseSongSections.mockReturnValue({
+        sections: [],
+        isLoading: true,
+        error: null,
+        refetch: vi.fn(),
+        createSection: vi.fn(),
+        updateSection: vi.fn(),
+        deleteSection: vi.fn(),
+        upsertSections: vi.fn(),
+        deleteAllSections: vi.fn(),
+      });
+
+      render(<SectionPicker {...defaultProps} />);
+
+      expect(screen.getByText('Loading sections...')).toBeInTheDocument();
+    });
+
+    it('should show error state when loading fails', () => {
+      mockUseSongSections.mockReturnValue({
+        sections: [],
+        isLoading: false,
+        error: new Error('Failed to load'),
+        refetch: vi.fn(),
+        createSection: vi.fn(),
+        updateSection: vi.fn(),
+        deleteSection: vi.fn(),
+        upsertSections: vi.fn(),
+        deleteAllSections: vi.fn(),
+      });
+
+      render(<SectionPicker {...defaultProps} />);
+
+      expect(screen.getByText('Failed to load sections')).toBeInTheDocument();
+    });
+
+    it('should show empty state when no sections exist', () => {
+      mockUseSongSections.mockReturnValue({
+        sections: [],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+        createSection: vi.fn(),
+        updateSection: vi.fn(),
+        deleteSection: vi.fn(),
+        upsertSections: vi.fn(),
+        deleteAllSections: vi.fn(),
+      });
+
+      render(<SectionPicker {...defaultProps} />);
+
+      expect(screen.getByText('No sections defined for this song')).toBeInTheDocument();
+    });
+
+    it('should render section chips when sections exist', () => {
+      render(<SectionPicker {...defaultProps} />);
+
+      expect(screen.getByRole('checkbox', { name: 'Intro' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'Verse 1' })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'Chorus' })).toBeInTheDocument();
+    });
+
+    it('should render with correct ARIA attributes', () => {
+      render(<SectionPicker {...defaultProps} />);
+
+      const group = screen.getByRole('group', { name: 'Select sections practiced' });
+      expect(group).toBeInTheDocument();
+
+      const introChip = screen.getByRole('checkbox', { name: 'Intro' });
+      expect(introChip).toHaveAttribute('aria-checked', 'false');
+    });
+  });
+
+  describe('selection behavior', () => {
+    it('should show selected state for selected sections', () => {
+      render(
+        <SectionPicker {...defaultProps} selectedSectionIds={['section-1', 'section-3']} />
+      );
+
+      const introChip = screen.getByRole('checkbox', { name: 'Intro' });
+      const verse1Chip = screen.getByRole('checkbox', { name: 'Verse 1' });
+      const chorusChip = screen.getByRole('checkbox', { name: 'Chorus' });
+
+      expect(introChip).toHaveAttribute('aria-checked', 'true');
+      expect(verse1Chip).toHaveAttribute('aria-checked', 'false');
+      expect(chorusChip).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should call onSelectionChange with added section when clicking unselected chip', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+
+      render(
+        <SectionPicker
+          {...defaultProps}
+          selectedSectionIds={['section-1']}
+          onSelectionChange={onSelectionChange}
+        />
+      );
+
+      const verse1Chip = screen.getByRole('checkbox', { name: 'Verse 1' });
+      await user.click(verse1Chip);
+
+      expect(onSelectionChange).toHaveBeenCalledWith(['section-1', 'section-2']);
+    });
+
+    it('should call onSelectionChange with removed section when clicking selected chip', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+
+      render(
+        <SectionPicker
+          {...defaultProps}
+          selectedSectionIds={['section-1', 'section-2']}
+          onSelectionChange={onSelectionChange}
+        />
+      );
+
+      const introChip = screen.getByRole('checkbox', { name: 'Intro' });
+      await user.click(introChip);
+
+      expect(onSelectionChange).toHaveBeenCalledWith(['section-2']);
+    });
+
+    it('should allow selecting multiple sections', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+
+      render(
+        <SectionPicker
+          {...defaultProps}
+          selectedSectionIds={[]}
+          onSelectionChange={onSelectionChange}
+        />
+      );
+
+      const introChip = screen.getByRole('checkbox', { name: 'Intro' });
+      await user.click(introChip);
+
+      expect(onSelectionChange).toHaveBeenCalledWith(['section-1']);
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('should toggle section on Enter key', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+
+      render(
+        <SectionPicker
+          {...defaultProps}
+          selectedSectionIds={[]}
+          onSelectionChange={onSelectionChange}
+        />
+      );
+
+      const introChip = screen.getByRole('checkbox', { name: 'Intro' });
+      introChip.focus();
+      await user.keyboard('{Enter}');
+
+      expect(onSelectionChange).toHaveBeenCalledWith(['section-1']);
+    });
+
+    it('should toggle section on Space key', async () => {
+      const user = userEvent.setup();
+      const onSelectionChange = vi.fn();
+
+      render(
+        <SectionPicker
+          {...defaultProps}
+          selectedSectionIds={['section-1']}
+          onSelectionChange={onSelectionChange}
+        />
+      );
+
+      const introChip = screen.getByRole('checkbox', { name: 'Intro' });
+      introChip.focus();
+      await user.keyboard(' ');
+
+      expect(onSelectionChange).toHaveBeenCalledWith([]);
+    });
+
+    it('should allow Tab navigation between chips', async () => {
+      const user = userEvent.setup();
+
+      render(<SectionPicker {...defaultProps} />);
+
+      const introChip = screen.getByRole('checkbox', { name: 'Intro' });
+      const verse1Chip = screen.getByRole('checkbox', { name: 'Verse 1' });
+
+      introChip.focus();
+      expect(document.activeElement).toBe(introChip);
+
+      await user.tab();
+      expect(document.activeElement).toBe(verse1Chip);
+    });
+  });
+
+  describe('displayName', () => {
+    it('should have displayName set', () => {
+      expect(SectionPicker.displayName).toBe('SectionPicker');
+    });
+  });
+
+  describe('className prop', () => {
+    it('should apply custom className', () => {
+      const { container } = render(
+        <SectionPicker {...defaultProps} className="custom-class" />
+      );
+
+      const group = container.querySelector('.custom-class');
+      expect(group).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -7,6 +7,7 @@ export { ConfirmDialog } from './ConfirmDialog';
 export { CreateBandDialog } from './CreateBandDialog';
 export { DangerousActionDialog } from './DangerousActionDialog';
 export { LogPracticeModal, type PracticeFormData } from './LogPracticeModal';
+export { SectionPicker, type SectionPickerProps } from './SectionPicker';
 export { ErrorBoundary } from './ErrorBoundary';
 export { ResizablePanel } from './ResizablePanel';
 export { Alert, AlertTitle, AlertDescription } from './Alert';

--- a/src/hooks/__tests__/usePracticeStats.test.ts
+++ b/src/hooks/__tests__/usePracticeStats.test.ts
@@ -8,6 +8,7 @@ import type { PracticeStats, PracticeSession } from '../../types';
 vi.mock('../../services/supabaseStorageService', () => ({
   supabaseStorageService: {
     calculatePracticeStats: vi.fn(),
+    calculateSectionPracticeStats: vi.fn(),
   },
 }));
 
@@ -49,6 +50,8 @@ describe('usePracticeStats', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default mock for section stats (returns empty map)
+    vi.mocked(supabaseStorageService.calculateSectionPracticeStats).mockResolvedValue(new Map());
   });
 
   describe('null/undefined input handling', () => {

--- a/src/hooks/usePracticeSessions.ts
+++ b/src/hooks/usePracticeSessions.ts
@@ -10,7 +10,8 @@ export interface LogPracticeSessionInput {
   songId: string;
   durationMinutes: number;
   tempoBpm?: number;
-  sectionsPracticed?: string[];
+  sectionsPracticed?: string[];  // Legacy: free-text section names
+  sectionIds?: string[];         // NEW: validated section UUIDs
   notes?: string;
   date: string;
 }

--- a/src/hooks/usePracticeStats.ts
+++ b/src/hooks/usePracticeStats.ts
@@ -2,34 +2,49 @@ import { useState, useEffect, useCallback } from 'react';
 import type { PracticeStats } from '../types';
 import { supabaseStorageService } from '../services/supabaseStorageService';
 
+/** Section-level practice statistics */
+export interface SectionPracticeStats {
+  totalMinutes: number;
+  sessionCount: number;
+}
+
 interface UsePracticeStatsResult {
   stats: PracticeStats | null;
+  /** Map of sectionId to section-level stats */
+  sectionStats: Map<string, SectionPracticeStats>;
   isLoading: boolean;
   error: Error | null;
   refetch: () => Promise<void>;
+}
+
+interface UsePracticeStatsOptions {
+  /** Filter stats to a specific song */
+  songId?: string;
 }
 
 /**
  * Custom hook to fetch aggregate practice statistics
  *
  * Fetches aggregate practice statistics including total sessions, minutes,
- * song progress counts, and recent sessions. Supports optional date range
- * filtering. Automatically refetches when userId, bandId, or dateRange changes.
+ * song progress counts, recent sessions, and section-level statistics.
+ * Supports optional date range filtering and song filtering.
+ * Automatically refetches when userId, bandId, options, or dateRange changes.
  * Returns null when userId or bandId is null.
  *
- * Note: dateRange object should be memoized in the calling component to avoid
- * unnecessary refetches on every render.
+ * Note: dateRange and options objects should be memoized in the calling component
+ * to avoid unnecessary refetches on every render.
  *
  * @param userId - User ID to fetch stats for
  * @param bandId - Band ID to filter stats by
  * @param dateRange - Optional date range filter { start: 'YYYY-MM-DD', end: 'YYYY-MM-DD' }
- * @returns Practice stats, loading state, error, and refetch function
+ * @param options - Optional options like songId filter
+ * @returns Practice stats, section stats, loading state, error, and refetch function
  *
  * @example
  * ```tsx
  * function PracticeOverview() {
  *   const dateRange = useMemo(() => ({ start: '2025-01-01', end: '2025-01-31' }), []);
- *   const { stats, isLoading, error, refetch } = usePracticeStats(
+ *   const { stats, sectionStats, isLoading, error, refetch } = usePracticeStats(
  *     user?.id || null,
  *     currentBandId,
  *     dateRange
@@ -43,8 +58,7 @@ interface UsePracticeStatsResult {
  *       <h2>Practice Stats</h2>
  *       <p>Total Sessions: {stats?.totalSessions || 0}</p>
  *       <p>Total Minutes: {stats?.totalMinutes || 0}</p>
- *       <p>Songs Learned: {stats?.songsLearned || 0}</p>
- *       <p>Songs Mastered: {stats?.songsMastered || 0}</p>
+ *       <p>Section stats: {sectionStats.size} sections tracked</p>
  *       <button onClick={refetch}>Refresh</button>
  *     </div>
  *   );
@@ -54,15 +68,18 @@ interface UsePracticeStatsResult {
 export function usePracticeStats(
   userId: string | null,
   bandId: string | null,
-  dateRange?: { start: string; end: string }
+  dateRange?: { start: string; end: string },
+  options?: UsePracticeStatsOptions
 ): UsePracticeStatsResult {
   const [stats, setStats] = useState<PracticeStats | null>(null);
+  const [sectionStats, setSectionStats] = useState<Map<string, SectionPracticeStats>>(new Map());
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
   const load = useCallback(async () => {
     if (!userId || !bandId) {
       setStats(null);
+      setSectionStats(new Map());
       setIsLoading(false);
       return;
     }
@@ -70,23 +87,35 @@ export function usePracticeStats(
     try {
       setIsLoading(true);
       setError(null);
+
+      // Fetch main stats
       const data = await supabaseStorageService.calculatePracticeStats(
         userId,
         bandId,
         dateRange
       );
       setStats(data);
+
+      // Fetch section-level stats
+      const sectionData = await supabaseStorageService.calculateSectionPracticeStats(
+        userId,
+        bandId,
+        options?.songId,
+        dateRange
+      );
+      setSectionStats(sectionData);
     } catch (err) {
       setError(err instanceof Error ? err : new Error('Failed to load practice statistics'));
       setStats(null);
+      setSectionStats(new Map());
     } finally {
       setIsLoading(false);
     }
-  }, [userId, bandId, dateRange]);
+  }, [userId, bandId, dateRange, options?.songId]);
 
   useEffect(() => {
     load();
   }, [load]);
 
-  return { stats, isLoading, error, refetch: load };
+  return { stats, sectionStats, isLoading, error, refetch: load };
 }

--- a/src/services/__tests__/practiceTracking.test.ts
+++ b/src/services/__tests__/practiceTracking.test.ts
@@ -135,6 +135,7 @@ describe('Practice Tracking Service Methods', () => {
         duration_minutes: validSession.durationMinutes,
         tempo_bpm: validSession.tempoBpm,
         sections_practiced: validSession.sectionsPracticed,
+        section_ids: null, // NEW: Phase 4 Practice Integration
         notes: validSession.notes,
         date: validSession.date,
       });
@@ -281,11 +282,13 @@ describe('Practice Tracking Service Methods', () => {
         duration_minutes: minimalSession.durationMinutes,
         tempo_bpm: null,
         sections_practiced: null,
+        section_ids: null, // NEW: Phase 4 Practice Integration
         notes: null,
         date: minimalSession.date,
       });
       expect(result.tempoBpm).toBeUndefined();
       expect(result.sectionsPracticed).toBeUndefined();
+      expect(result.sectionIds).toBeUndefined(); // NEW: Phase 4 Practice Integration
       expect(result.notes).toBeUndefined();
     });
   });

--- a/src/services/supabaseStorageService.ts
+++ b/src/services/supabaseStorageService.ts
@@ -2071,7 +2071,9 @@ export class SupabaseStorageService implements IStorageService {
         const sectionIds = session.section_ids;
         if (!sectionIds || sectionIds.length === 0) continue;
 
-        // Distribute duration equally across sections
+        // Distribute duration equally across sections when multiple sections are logged together.
+        // This is a simplification since we don't track per-section time within a session.
+        // Future enhancement: Allow users to specify per-section duration in LogPracticeModal.
         const perSectionMinutes = session.duration_minutes / sectionIds.length;
 
         for (const sectionId of sectionIds) {

--- a/src/services/supabaseStorageService.ts
+++ b/src/services/supabaseStorageService.ts
@@ -2036,7 +2036,7 @@ export class SupabaseStorageService implements IStorageService {
       // Note: section_ids column not yet in generated types, use raw query approach
       let query = supabase
         .from('practice_sessions')
-        .select('duration_minutes')
+        .select('duration_minutes, section_ids')
         .eq('user_id', userId)
         .eq('band_id', bandId);
 
@@ -2063,8 +2063,9 @@ export class SupabaseStorageService implements IStorageService {
 
       // TODO: Remove type assertion after running `supabase gen types` to include section_ids column
       // The database has section_ids but types haven't been regenerated yet
+      // Cast through unknown since generated types don't include section_ids column
       type SessionWithSectionIds = { duration_minutes: number; section_ids?: string[] | null };
-      const sessionsWithSectionIds = data as SessionWithSectionIds[] | null;
+      const sessionsWithSectionIds = data as unknown as SessionWithSectionIds[] | null;
 
       for (const session of sessionsWithSectionIds ?? []) {
         const sectionIds = session.section_ids;

--- a/src/services/supabaseStorageService.ts
+++ b/src/services/supabaseStorageService.ts
@@ -1453,7 +1453,8 @@ export class SupabaseStorageService implements IStorageService {
           band_id: session.bandId,
           duration_minutes: session.durationMinutes,
           tempo_bpm: session.tempoBpm ?? null,
-          sections_practiced: session.sectionsPracticed ?? null,
+          sections_practiced: session.sectionsPracticed ?? null, // Legacy
+          section_ids: session.sectionIds ?? null,               // NEW: validated section UUIDs
           notes: session.notes ?? null,
           date: session.date,
         })
@@ -1551,6 +1552,8 @@ export class SupabaseStorageService implements IStorageService {
   private transformPracticeSession(
     row: Database['public']['Tables']['practice_sessions']['Row']
   ): PracticeSession {
+    // TODO: Remove type assertion after running `supabase gen types` to include section_ids column
+    const rowWithSectionIds = row as typeof row & { section_ids?: string[] | null };
     return {
       id: row.id,
       userId: row.user_id,
@@ -1559,6 +1562,7 @@ export class SupabaseStorageService implements IStorageService {
       durationMinutes: row.duration_minutes,
       tempoBpm: row.tempo_bpm ?? undefined,
       sectionsPracticed: (row.sections_practiced as string[] | null) ?? undefined,
+      sectionIds: rowWithSectionIds.section_ids ?? undefined,
       notes: row.notes ?? undefined,
       date: row.date,
       createdAt: row.created_at,
@@ -1595,6 +1599,7 @@ export class SupabaseStorageService implements IStorageService {
       if ('durationMinutes' in updates) updatePayload.duration_minutes = updates.durationMinutes;
       if ('tempoBpm' in updates) updatePayload.tempo_bpm = updates.tempoBpm ?? null;
       if ('sectionsPracticed' in updates) updatePayload.sections_practiced = updates.sectionsPracticed ?? null;
+      if ('sectionIds' in updates) updatePayload.section_ids = updates.sectionIds ?? null;
       if ('notes' in updates) updatePayload.notes = updates.notes ?? null;
       if ('date' in updates) updatePayload.date = updates.date;
       if ('songId' in updates) updatePayload.song_id = updates.songId;
@@ -1995,6 +2000,92 @@ export class SupabaseStorageService implements IStorageService {
     } catch (error) {
       console.error('Error in calculatePracticeStats:', error);
       throw error instanceof Error ? error : new Error('Failed to calculate practice statistics');
+    }
+  }
+
+  /**
+   * Calculate section-level practice statistics
+   *
+   * Aggregates practice time and session counts per section based on section_ids
+   * in practice sessions. When multiple sections are logged in one session,
+   * the duration is distributed equally across sections.
+   *
+   * @param userId - User ID to calculate stats for
+   * @param bandId - Band ID to filter stats by
+   * @param songId - Optional song ID to filter stats to a specific song
+   * @param dateRange - Optional date range filter
+   * @returns Map of sectionId to { totalMinutes, sessionCount }
+   */
+  async calculateSectionPracticeStats(
+    userId: string,
+    bandId: string,
+    songId?: string,
+    dateRange?: { start: string; end: string }
+  ): Promise<Map<string, { totalMinutes: number; sessionCount: number }>> {
+    const supabase = getSupabaseClient();
+    if (!supabase) {
+      throw new Error('Supabase is not configured. Check environment variables.');
+    }
+
+    if (!this.currentBandId) {
+      throw new Error('No band selected. Call setCurrentBand() first.');
+    }
+
+    try {
+      // Query for sessions with section_ids
+      // Note: section_ids column not yet in generated types, use raw query approach
+      let query = supabase
+        .from('practice_sessions')
+        .select('duration_minutes')
+        .eq('user_id', userId)
+        .eq('band_id', bandId);
+
+      if (songId) {
+        query = query.eq('song_id', songId);
+      }
+
+      if (dateRange?.start) {
+        query = query.gte('date', dateRange.start);
+      }
+      if (dateRange?.end) {
+        query = query.lte('date', dateRange.end);
+      }
+
+      const { data, error } = await query;
+
+      if (error) {
+        console.error('Error fetching section practice stats:', error);
+        throw new Error('Failed to calculate section statistics');
+      }
+
+      // Aggregate results into Map
+      const sectionStats = new Map<string, { totalMinutes: number; sessionCount: number }>();
+
+      // TODO: Remove type assertion after running `supabase gen types` to include section_ids column
+      // The database has section_ids but types haven't been regenerated yet
+      type SessionWithSectionIds = { duration_minutes: number; section_ids?: string[] | null };
+      const sessionsWithSectionIds = data as SessionWithSectionIds[] | null;
+
+      for (const session of sessionsWithSectionIds ?? []) {
+        const sectionIds = session.section_ids;
+        if (!sectionIds || sectionIds.length === 0) continue;
+
+        // Distribute duration equally across sections
+        const perSectionMinutes = session.duration_minutes / sectionIds.length;
+
+        for (const sectionId of sectionIds) {
+          const existing = sectionStats.get(sectionId) ?? { totalMinutes: 0, sessionCount: 0 };
+          sectionStats.set(sectionId, {
+            totalMinutes: existing.totalMinutes + perSectionMinutes,
+            sessionCount: existing.sessionCount + 1,
+          });
+        }
+      }
+
+      return sectionStats;
+    } catch (error) {
+      console.error('Error in calculateSectionPracticeStats:', error);
+      throw error instanceof Error ? error : new Error('Failed to calculate section statistics');
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,7 +155,8 @@ export interface PracticeSession {
   bandId: string;
   durationMinutes: number;
   tempoBpm?: number;
-  sectionsPracticed?: string[]; // e.g., ["Intro", "Chorus", "Solo 1"]
+  sectionsPracticed?: string[]; // Legacy: free-text section names (e.g., ["Intro", "Chorus", "Solo 1"])
+  sectionIds?: string[];        // NEW: array of song_sections.id UUIDs for validated section tracking
   notes?: string;
   date: string; // YYYY-MM-DD
   createdAt: string;
@@ -190,7 +191,7 @@ export interface PracticeFilters {
 
 /** Input data for updating an existing practice session */
 export type UpdatePracticeSessionInput = Partial<
-  Pick<PracticeSession, 'durationMinutes' | 'tempoBpm' | 'sectionsPracticed' | 'notes' | 'date' | 'songId'>
+  Pick<PracticeSession, 'durationMinutes' | 'tempoBpm' | 'sectionsPracticed' | 'sectionIds' | 'notes' | 'date' | 'songId'>
 >;
 
 // =============================================================================

--- a/supabase/migrations/028_add_section_ids_to_practice_sessions.sql
+++ b/supabase/migrations/028_add_section_ids_to_practice_sessions.sql
@@ -1,0 +1,44 @@
+-- Migration: Add section_ids to practice_sessions
+-- Phase 4: Practice Integration - Section-aware practice logging
+-- Created: 20251221
+
+-- =============================================================================
+-- ADD SECTION_IDS COLUMN
+-- =============================================================================
+
+-- Add section_ids column for validated section references
+ALTER TABLE practice_sessions
+ADD COLUMN section_ids UUID[] DEFAULT NULL;
+
+-- Create GIN index for efficient array queries (e.g., @> contains, && overlaps)
+CREATE INDEX idx_practice_sessions_section_ids
+ON practice_sessions USING GIN (section_ids);
+
+-- Documentation
+COMMENT ON COLUMN practice_sessions.section_ids IS
+  'Array of song_sections.id UUIDs practiced in this session. Replaces free-text sections_practiced field for validated section tracking.';
+
+-- =============================================================================
+-- VERIFICATION
+-- =============================================================================
+
+DO $$
+BEGIN
+  -- Check column exists
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'practice_sessions' AND column_name = 'section_ids'
+  ) THEN
+    RAISE EXCEPTION 'Migration failed: section_ids column not created';
+  END IF;
+
+  -- Check index exists
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE tablename = 'practice_sessions' AND indexname = 'idx_practice_sessions_section_ids'
+  ) THEN
+    RAISE EXCEPTION 'Migration failed: idx_practice_sessions_section_ids not created';
+  END IF;
+
+  RAISE NOTICE 'Migration 028_add_section_ids_to_practice_sessions completed successfully';
+END $$;

--- a/supabase/migrations/028_add_section_ids_to_practice_sessions.sql
+++ b/supabase/migrations/028_add_section_ids_to_practice_sessions.sql
@@ -42,3 +42,16 @@ BEGIN
 
   RAISE NOTICE 'Migration 028_add_section_ids_to_practice_sessions completed successfully';
 END $$;
+
+-- =============================================================================
+-- DOWN MIGRATION (for rollback)
+-- =============================================================================
+-- To rollback this migration, run the following commands:
+--
+-- DROP INDEX IF EXISTS idx_practice_sessions_section_ids;
+-- ALTER TABLE practice_sessions DROP COLUMN IF EXISTS section_ids;
+--
+-- Note: Rolling back will permanently lose any section_ids data stored after
+-- this migration was applied. The legacy sections_practiced column is preserved
+-- as a fallback.
+-- =============================================================================


### PR DESCRIPTION
## Summary

Implements **Phase 4 Practice Integration**, enabling section-aware practice logging with validated section IDs instead of free-text section names. This provides granular practice analytics, allowing users to identify which sections need more attention and track progress at a structural level.

**Key Features:**
- Database migration to add `section_ids` column for validated section tracking
- SectionPicker component for selecting sections in LogPracticeModal
- Keyboard shortcuts (1-9, arrow keys) for section navigation in Practice Room
- Section filter in PracticeHistory
- SectionStatsCard for per-section practice statistics
- usePracticeStats extended with sectionStats

This is **Phase 4 of 5** in the Song Collaboration & Annotation Architecture Plan.

## Changes

The following 17 files were modified or created:

```
specs/feat-phase4-practice-integration.md          | 614 ++++++++++++++++++++++++
src/components/PracticeHistory.tsx                 |  81 ++-
src/components/__tests__/PracticeHistory.test.tsx  | 130 ++---
src/components/practice/SectionNav.tsx             |  72 ++-
src/components/structure/SectionStatsCard.tsx      | 174 ++++++
src/components/structure/index.ts                  |   2 +
src/components/ui/LogPracticeModal.tsx             |  50 +-
src/components/ui/SectionPicker.tsx                | 134 +++++
src/components/ui/__tests__/LogPracticeModal.test.tsx |  29 +-
src/components/ui/index.ts                         |   1 +
src/hooks/__tests__/usePracticeStats.test.ts       |   3 +
src/hooks/usePracticeSessions.ts                   |   3 +-
src/hooks/usePracticeStats.ts                      |  51 +-
src/services/__tests__/practiceTracking.test.ts    |   3 +
src/services/supabaseStorageService.ts             |  93 +-
src/types.ts                                       |   5 +-
supabase/migrations/028_add_section_ids_to_practice_sessions.sql |  44 ++

Total: 1343 insertions(+), 146 deletions(-)
```

## Implementation Details

### Database
- Added `section_ids UUID[]` column to `practice_sessions` table via migration
- Created GIN index for efficient array queries
- Maintains backwards compatibility with existing `sections_practiced TEXT[]` column

### New Components
- **SectionPicker**: Selectable chips for choosing sections when logging practice
- **SectionStatsCard**: Displays per-section practice statistics in SongDetail

### Enhanced Features
- **LogPracticeModal**: Integrated SectionPicker for section selection
- **Practice Room (SectionNav)**: Added keyboard shortcuts (1-9 for sections, arrow keys for navigation)
- **PracticeHistory**: Added section filter dropdown
- **usePracticeStats**: Extended with `bySection` map for section-level analytics

### Keyboard Shortcuts
- **Keys 1-9**: Jump to sections 1-9 in Practice Room
- **Arrow Keys**: Navigate to previous/next section
- Shortcuts only active when SectionNav container has focus
- Keyboard conflicts with AlphaTab prevented via event capture

## Test Plan

- [ ] Database migration applies cleanly and is reversible
- [ ] New sections can be selected and logged in LogPracticeModal
- [ ] Section filter in PracticeHistory filters sessions correctly
- [ ] Keyboard shortcuts navigate sections in Practice Room
- [ ] SectionStatsCard displays accurate per-section statistics
- [ ] Backwards compatibility maintained for sessions with free-text sections
- [ ] All tests pass: `npm test`
- [ ] No TypeScript errors: `npm run typecheck`
- [ ] No lint warnings: `npm run lint`

## Architecture

This PR continues the **Song Collaboration & Annotation Architecture Plan**:

1. ✅ **Phase 1**: Song sections (structural breakdown)
2. ✅ **Phase 2**: Section assignments (member roles)
3. ✅ **Phase 3**: Song annotations (real-time sync)
4. ✅ **Phase 4**: Practice integration (section-aware logging) — **THIS PR**
5. 🔄 **Phase 5**: Collaboration tools (pending)

See `specs/feat-phase4-practice-integration.md` for full specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Section filtering in Practice History for song-specific views
  * Per-section practice stats with visual bars (minutes & session counts)
  * Section selection UI when logging practice sessions (validated selections)
  * Keyboard shortcuts (1–9 and arrow keys) for fast section navigation in Practice Room

* **Documentation**
  * Added Phase 4 Practice Integration specification

* **Tests**
  * Added/updated tests covering SectionPicker, section stats, logging modal, and history flows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->