### PR TITLE
fix(practice): sections selected during logging now display in history table

### DIFF
--- a/src/services/supabaseStorageService.ts
+++ b/src/services/supabaseStorageService.ts
@@ -2145,6 +2145,40 @@ export class SupabaseStorageService implements IStorageService {
   }
 
   /**
+   * Get sections by their IDs (for resolving section names in practice history)
+   * Returns a Map for efficient lookups
+   */
+  async getSectionsByIds(sectionIds: string[]): Promise<Map<string, SongSection>> {
+    const supabase = getSupabaseClient();
+    if (!supabase) {
+      throw new Error('Supabase is not configured. Check environment variables.');
+    }
+
+    // Return empty map if no IDs provided
+    if (sectionIds.length === 0) {
+      return new Map();
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('song_sections')
+        .select('*')
+        .in('id', sectionIds);
+
+      if (error) {
+        console.error('Error fetching sections by IDs:', error);
+        throw new Error('Failed to load sections');
+      }
+
+      const sections = (data || []).map(row => this.transformSongSection(row));
+      return new Map(sections.map(section => [section.id, section]));
+    } catch (error) {
+      console.error('Error in getSectionsByIds:', error);
+      throw error instanceof Error ? error : new Error('Failed to load sections');
+    }
+  }
+
+  /**
    * Create a new section
    */
   async createSection(input: SongSectionInput): Promise<SongSection> {


### PR DESCRIPTION
## Summary

Fixes issue #248: Sections selected during practice session logging were not appearing in the Practice History table. The fix adds section resolution logic that maps sectionIds (UUIDs) to section names while gracefully handling deleted sections.

## Changes

- **supabaseStorageService.ts**: Added `getSectionsByIds()` method for bulk fetching sections by UUID
- **PracticeHistory.tsx**: 
  - Created `resolveSectionNames()` helper that validates UUIDs and prefers sectionIds over legacy sectionsPracticed text
  - Added state management to fetch and cache sections for displayed practice sessions
  - Updated VirtualizedSessionTable to accept sectionMap prop and display resolved section names
  - Added muted/italic styling for "Unknown section" when a section has been deleted
- **PracticeHistory.test.tsx**: Added comprehensive tests for section resolution and deleted section handling

## Files Modified

- src/components/PracticeHistory.tsx (+115, -8)
- src/components/__tests__/PracticeHistory.test.tsx (+117, -1)
- src/services/supabaseStorageService.ts (+34)

## Test Plan

- [x] Section names selected during logging now appear in Practice History table
- [x] Deleted sections display as "Unknown section" in italic/muted text
- [x] UUID validation prevents invalid section ID resolution
- [x] Section name resolution handles edge cases correctly
- [x] All existing tests pass

## Related

Closes #248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added section filtering capability in practice history.
  * Practice sessions now properly display resolved section names from the database.

* **Bug Fixes**
  * Unknown or deleted sections are now clearly marked in practice history records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->